### PR TITLE
Fixed issue #34 - Fixed typo in javadoc for after(final EventProcessor.....

### DIFF
--- a/code/src/main/com/lmax/disruptor/dsl/Disruptor.java
+++ b/code/src/main/com/lmax/disruptor/dsl/Disruptor.java
@@ -163,7 +163,7 @@ public class Disruptor<T>
      *
      * @param processors the event processors, previously set up with {@link #handleEventsWith(com.lmax.disruptor.EventProcessor...)},
      *                   that will form the barrier for subsequent handlers or processors.
-     * @return an {@link EventHandlerGroup} that can be used to setup a {@link SequenceBarrier} over hte specified event processors.
+     * @return an {@link EventHandlerGroup} that can be used to setup a {@link SequenceBarrier} over the specified event processors.
      * @see #after(com.lmax.disruptor.EventHandler[])
      */
     public EventHandlerGroup<T> after(final EventProcessor... processors)


### PR DESCRIPTION
.... processors)
