### PR TITLE
A bug report & fixed about Disruptor.shutdown()

### DIFF
--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -322,10 +322,16 @@ public class Disruptor<T>
         final long cursor = ringBuffer.getCursor();
         for (Sequence consumer : consumerRepository.getLastSequenceInChain())
         {
-            if (cursor != consumer.get())
+            /*
+             * change '!=' to '>', because the WorkProcessor has processedSequence,
+             * more then one WorProcessor will be large then the ringbuffer.cursor.
+             * oldmanpushcart@gmail.com
+             */
+            if (cursor > consumer.get())
             {
                 return true;
             }
+            
         }
         return false;
     }


### PR DESCRIPTION
Hi, when I work with the WorkPool, I found disruptor can't shutdown, I found WorkProcessor has 'processedSequence', if more then one WorkProcessor in Pool, the method 'hasBacklog()' in Disruptor alway return true of all times.

So I solve the problem for me, and let you know this may be a bug.
