### PR TITLE
Adjustable condition await timeout in PhasedBackoffWaitStrategy.LockBlockingStrategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'checkstyle'
 defaultTasks 'build'
 
 group = 'com.lmax'
-version = new Version(major: 3, minor: 2, revision: 0)
+version = new Version(major: 3, minor: 2, revision: 1, snapshot: true)
 
 ext {
     fullName = 'Disruptor Framework'


### PR DESCRIPTION
When running benchmarking of Disruptor on Mac OS X 10.8.5 using the `PhasedBackoffWaitStrategy.withLock(...)` wait strategy the CPU remained at 100% utilization even after the queue producers and consumers were finished.

With the change included in the pull request I was able to compare and quantify the effect of adjusting from the originally hard-coded 1 millisecond `condition.await` timeout. In order to reveal the "idle" effects, the benchmark application includes a 10 second `Thread.sleep` after the producers have completed. Further measuring the process with `time`, the "user" duration roughly indicates the relative amount of "busy during idle".

Here are two executions, the first with the default 1 millisecond (1m43s user time) and the second with a 500 millisecond (0m35s user time) await timeout:

```
localhost$ time java -jar target/benchmark-0.0.1-SNAPSHOT.jar --technology GROOVY_DISRUPTOR --wait-strategy PHASED_ADJUSTABLE_BACKOFF --yield-timeout 1 --lock-wait-timeout 1
Inputs       : Benchmark:[technology=GROOVY_DISRUPTOR, producers=3,  consumers=10, iterations=5000000, messagePoolSize=1000, postBenchmarkRest=10, disruptorWaitStrategy=PHASED_ADJUSTABLE_BACKOFF, lockWaitTimeoutMillis=1]
Duration     : 3878640000 nanoseconds, 3.878640 seconds
Latency      : 258 nanoseconds/msg
Rate         : 5,000,000 msg/sec

real    0m14.725s
user    1m43.095s
sys 0m0.811s
localhost$ time java -jar target/benchmark-0.0.1-SNAPSHOT.jar --technology GROOVY_DISRUPTOR --wait-strategy PHASED_ADJUSTABLE_BACKOFF --yield-timeout 1 --lock-wait-timeout 500
Inputs       : Benchmark:[technology=GROOVY_DISRUPTOR, producers=3,  consumers=10, iterations=5000000, messagePoolSize=1000, postBenchmarkRest=10, disruptorWaitStrategy=PHASED_ADJUSTABLE_BACKOFF, lockWaitTimeoutMillis=500]
Duration     : 4506909000 nanoseconds, 4.506909 seconds
Latency      : 300 nanoseconds/msg
Rate         : 3,750,000 msg/sec

real    0m15.340s
user    0m35.013s
sys 0m0.306s
```
