### PR TITLE
Updated Gradle so IntelliJ can pick up the performance test classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ sourceSets {
 
 eclipse.classpath.plusConfigurations += sourceSets.perf.compileClasspath
 
+idea.module {
+    testSourceDirs += sourceSets.perf.allSource.getSrcDirs()
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
This change in Gradle adds the per source as a test source root if you generate your idea files using "./gradlew idea".  However, IntelliJ won't be able to run the tests as it does not add the perf dependencies into the IntelliJ settings - this either has to be done manually by the user, or the Gradle build can be updated to add these settings to the IntelliJ settings via XML unpleasantness.
