### PR TITLE
Add LoadSensitiveWait Strategy.

### DIFF
--- a/src/main/java/com/lmax/disruptor/LoadSensitiveWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/LoadSensitiveWaitStrategy.java
@@ -1,0 +1,94 @@
+package com.lmax.disruptor;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.lmax.disruptor.AlertException;
+import com.lmax.disruptor.Sequence;
+import com.lmax.disruptor.SequenceBarrier;
+import com.lmax.disruptor.WaitStrategy;
+
+/**
+ * LoadSensitive strategy is the combined strategy that use BusySpin and BlockingWait. 
+ * It achieves similar high throughput and low latency as BusySpin Strategy in high load scenarios,
+ * while performs like BlockingWait strategy in idle state to save CPU power and system resource.
+ * The basic concept is somehow similar with PhasedBackOffWait Strategy, but the performance is better and 
+ * easier to use without customizations.
+ */
+public final class LoadSensitiveWaitStrategy implements WaitStrategy
+{
+    private static final int DEFAULT_RETRIES = 10;
+    
+    private final Lock lock = new ReentrantLock();
+    private final Condition processorNotifyCondition = lock.newCondition();
+    private AtomicBoolean waitOnLock = new AtomicBoolean(false); 
+
+    private final int retries;
+
+    public LoadSensitiveWaitStrategy()
+    {
+        this(DEFAULT_RETRIES);
+    }
+
+    public LoadSensitiveWaitStrategy(int retries)
+    {
+        this.retries = retries;
+    }
+    
+   
+    @Override
+    public long waitFor(final long sequence, Sequence cursor, final Sequence dependentSequence, final SequenceBarrier barrier)
+        throws AlertException, InterruptedException
+    {
+        long availableSequence;
+        int counter = retries;
+
+        while ((availableSequence = dependentSequence.get()) < sequence)
+        {
+        	barrier.checkAlert();
+
+            if (counter > 0)
+            {
+                --counter;
+            }
+            else
+            {
+            	lock.lock();
+            	try {
+            		waitOnLock.set(true);
+            		if ((availableSequence = dependentSequence.get()) >= sequence)
+                    {
+                        break;
+                    }
+        			processorNotifyCondition.await();
+        		} 
+            	finally
+            	{
+            	   lock.unlock();
+            	}           
+            }
+            
+        }
+        
+        return availableSequence;
+    }
+
+    @Override
+    public void signalAllWhenBlocking()
+    {
+    	if(waitOnLock.getAndSet(false)){
+	    	lock.lock();
+	    	try
+		    {
+	    		processorNotifyCondition.signalAll();
+		    }
+		    finally
+		    {
+		    	lock.unlock();
+		    }
+    	}
+    }
+}
+


### PR DESCRIPTION
Request to add a new wait strategy -- Load Sensitive Wait Strategy
LoadSensitive strategy is the combined strategy that use BusySpin and BlockingWait together. It achieves similar high throughput and low latency as BusySpin Strategy in high load scenarios, while performs like BlockingWait strategy in idle state to save CPU power and system resource.
The basic concept is a bit similar with PhasedBackOffWait Strategy, but the performance is better and easier to use without customizations.

Performance test measured by "TwoToTwoWorkProcessorThroughputTest":
********_BusySpinWait**_******
Starting Disruptor tests
Run 0, Disruptor=6,622,516 ops/sec
Run 1, Disruptor=6,944,444 ops/sec
Run 2, Disruptor=14,285,714 ops/sec
Run 3, Disruptor=22,727,272 ops/sec
Run 4, Disruptor=7,575,757 ops/sec
Run 5, Disruptor=7,092,198 ops/sec
Run 6, Disruptor=8,620,689 ops/sec
********_BlockingWait**_******
Starting Disruptor tests
Run 0, Disruptor=3,184,713 ops/sec
Run 1, Disruptor=4,385,964 ops/sec
Run 2, Disruptor=4,201,680 ops/sec
Run 3, Disruptor=4,201,680 ops/sec
Run 4, Disruptor=4,132,231 ops/sec
Run 5, Disruptor=3,968,253 ops/sec
Run 6, Disruptor=3,472,222 ops/sec
********_LoadSensitiveWait**_******
Starting Disruptor tests
Run 0, Disruptor=8,547,008 ops/sec
Run 1, Disruptor=11,494,252 ops/sec
Run 2, Disruptor=10,000,000 ops/sec
Run 3, Disruptor=11,494,252 ops/sec
Run 4, Disruptor=9,345,794 ops/sec
Run 5, Disruptor=9,615,384 ops/sec
Run 6, Disruptor=5,847,953 ops/sec

In the test, BusySpinWait Strategy achieved highest ops/sec, but CPU utilization was also as high as about 61%. BlockingWait strategy got much lower ops/sec, but CPU utilization consumed was only 14%. The new LoadSensitive strategy is the good compromise of both throughput/latency and CPU power. It got  no bat opts/sec as well as cosuming only 16% CPU utilization.
