### PR TITLE
Introduces Backchannels

### DIFF
--- a/src/main/java/com/lmax/disruptor/Backchannel.java
+++ b/src/main/java/com/lmax/disruptor/Backchannel.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor;
+
+public interface Backchannel
+{
+    /**
+     * Checks whether this Backchannel needs to be processed.
+     *
+     * @return true if there is work to be performed
+     */
+    boolean shouldProcess();
+
+    /**
+     * Processes whatever work is in this Backchannel. Can be called regardless
+     * of the result of shouldProcess(). This is called at well defined times
+     * (e.g., at the end of a batch by the BatchEventProcessor).
+     */
+    void process();
+
+    /**
+     * Registers a WaitStrategy that producers should notify when adding
+     * work to this Backchannel.
+     *
+     * @param waitStrategy the WaitStrategy to notify
+     */
+    void prepareWait(WaitStrategy waitStrategy);
+
+    void waitDone();
+
+    Backchannel NONE = new Backchannel() {
+
+        @Override
+        public boolean shouldProcess()
+        {
+            return false;
+        }
+
+        @Override
+        public void process()
+        {
+        }
+
+        @Override
+        public void prepareWait(WaitStrategy waitStrategy)
+        {
+        }
+
+        @Override
+        public void waitDone()
+        {
+        }
+    };
+}

--- a/src/main/java/com/lmax/disruptor/BusySpinWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/BusySpinWaitStrategy.java
@@ -25,12 +25,14 @@ package com.lmax.disruptor;
 public final class BusySpinWaitStrategy implements WaitStrategy
 {
     @Override
-    public long waitFor(final long sequence, Sequence cursor, final Sequence dependentSequence, final SequenceBarrier barrier)
+    public long waitFor(final long sequence, Sequence cursor, final Sequence dependentSequence,
+                        final Backchannel backchannel, final SequenceBarrier barrier)
         throws AlertException, InterruptedException
     {
         long availableSequence;
 
-        while ((availableSequence = dependentSequence.get()) < sequence)
+        while ((availableSequence = dependentSequence.get()) < sequence &&
+               !backchannel.shouldProcess())
         {
             barrier.checkAlert();
         }

--- a/src/main/java/com/lmax/disruptor/ProcessingSequenceBarrier.java
+++ b/src/main/java/com/lmax/disruptor/ProcessingSequenceBarrier.java
@@ -50,9 +50,19 @@ final class ProcessingSequenceBarrier implements SequenceBarrier
     public long waitFor(final long sequence)
         throws AlertException, InterruptedException, TimeoutException
     {
+        return waitFor(sequence, Backchannel.NONE);
+    }
+
+    @Override
+    public long waitFor(final long sequence, final Backchannel backchannel)
+        throws AlertException, InterruptedException, TimeoutException
+    {
         checkAlert();
 
-        long availableSequence = waitStrategy.waitFor(sequence, cursorSequence, dependentSequence, this);
+        backchannel.prepareWait(waitStrategy);
+        long availableSequence = waitStrategy.waitFor(sequence, cursorSequence, dependentSequence,
+                                                      backchannel, this);
+        backchannel.waitDone();
 
         if (availableSequence < sequence)
         {

--- a/src/main/java/com/lmax/disruptor/SequenceBarrier.java
+++ b/src/main/java/com/lmax/disruptor/SequenceBarrier.java
@@ -31,7 +31,11 @@ public interface SequenceBarrier
      * @throws InterruptedException if the thread needs awaking on a condition variable.
      * @throws TimeoutException
      */
-    long waitFor(long sequence) throws AlertException, InterruptedException, TimeoutException;
+    long waitFor(long sequence)
+        throws AlertException, InterruptedException, TimeoutException;
+
+    long waitFor(long sequence, Backchannel backchannel)
+        throws AlertException, InterruptedException, TimeoutException;
 
     /**
      * Get the current cursor value that can be read.

--- a/src/main/java/com/lmax/disruptor/SleepingWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/SleepingWaitStrategy.java
@@ -28,13 +28,15 @@ public final class SleepingWaitStrategy implements WaitStrategy
     private static final int RETRIES = 200;
 
     @Override
-    public long waitFor(final long sequence, Sequence cursor, final Sequence dependentSequence, final SequenceBarrier barrier)
+    public long waitFor(final long sequence, Sequence cursor, final Sequence dependentSequence,
+                        final Backchannel backchannel, final SequenceBarrier barrier)
         throws AlertException, InterruptedException
     {
         long availableSequence;
         int counter = RETRIES;
 
-        while ((availableSequence = dependentSequence.get()) < sequence)
+        while ((availableSequence = dependentSequence.get()) < sequence &&
+               !backchannel.shouldProcess())
         {
             counter = applyWaitMethod(barrier, counter);
         }

--- a/src/main/java/com/lmax/disruptor/WaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/WaitStrategy.java
@@ -38,7 +38,8 @@ public interface WaitStrategy
      * @throws InterruptedException if the thread is interrupted.
      * @throws TimeoutException
      */
-    long waitFor(long sequence, Sequence cursor, Sequence dependentSequence, SequenceBarrier barrier)
+    long waitFor(long sequence, Sequence cursor, Sequence dependentSequence,
+                 Backchannel backchannel, SequenceBarrier barrier)
         throws AlertException, InterruptedException, TimeoutException;
 
     /**

--- a/src/main/java/com/lmax/disruptor/WorkProcessor.java
+++ b/src/main/java/com/lmax/disruptor/WorkProcessor.java
@@ -140,7 +140,7 @@ public final class WorkProcessor<T>
                 }
                 else
                 {
-                    cachedAvailableSequence = sequenceBarrier.waitFor(nextSequence);
+                    cachedAvailableSequence = sequenceBarrier.waitFor(nextSequence, Backchannel.NONE);
                 }
             }
             catch (final AlertException ex)

--- a/src/main/java/com/lmax/disruptor/YieldingWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/YieldingWaitStrategy.java
@@ -15,7 +15,6 @@
  */
 package com.lmax.disruptor;
 
-
 /**
  * Yielding strategy that uses a Thread.yield() for {@link com.lmax.disruptor.EventProcessor}s waiting on a barrier
  * after an initially spinning.
@@ -27,13 +26,15 @@ public final class YieldingWaitStrategy implements WaitStrategy
     private static final int SPIN_TRIES = 100;
 
     @Override
-    public long waitFor(final long sequence, Sequence cursor, final Sequence dependentSequence, final SequenceBarrier barrier)
+    public long waitFor(final long sequence, Sequence cursor, final Sequence dependentSequence,
+                        final Backchannel backchannel, final SequenceBarrier barrier)
         throws AlertException, InterruptedException
     {
         long availableSequence;
         int counter = SPIN_TRIES;
 
-        while ((availableSequence = dependentSequence.get()) < sequence)
+        while ((availableSequence = dependentSequence.get()) < sequence &&
+               !backchannel.shouldProcess())
         {
             counter = applyWaitMethod(barrier, counter);
         }

--- a/src/test/java/com/lmax/disruptor/DummySequenceBarrier.java
+++ b/src/test/java/com/lmax/disruptor/DummySequenceBarrier.java
@@ -25,6 +25,12 @@ class DummySequenceBarrier implements SequenceBarrier
     }
 
     @Override
+    public long waitFor(long sequence, Backchannel backchannel) throws AlertException, InterruptedException
+    {
+        return 0;
+    }
+
+    @Override
     public long getCursor()
     {
         return 0;

--- a/src/test/java/com/lmax/disruptor/TimeoutBlockingWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/TimeoutBlockingWaitStrategyTest.java
@@ -37,7 +37,7 @@ public class TimeoutBlockingWaitStrategyTest
 
         try
         {
-            waitStrategy.waitFor(6, cursor, dependent, sequenceBarrier);
+            waitStrategy.waitFor(6, cursor, dependent, Backchannel.NONE, sequenceBarrier);
             fail("TimeoutException should have been thrown");
         }
         catch (TimeoutException e)

--- a/src/test/java/com/lmax/disruptor/WaitStrategyTestUtil.java
+++ b/src/test/java/com/lmax/disruptor/WaitStrategyTestUtil.java
@@ -33,7 +33,7 @@ public class WaitStrategyTestUtil
         EXECUTOR.execute(sequenceUpdater);
         sequenceUpdater.waitForStartup();
         Sequence cursor = new Sequence(0);
-        long sequence = waitStrategy.waitFor(0, cursor, sequenceUpdater.sequence, new DummySequenceBarrier());
+        long sequence = waitStrategy.waitFor(0, cursor, sequenceUpdater.sequence, Backchannel.NONE, new DummySequenceBarrier());
 
         assertThat(sequence, is(0L));
     }


### PR DESCRIPTION
This patch adds an overload of Sequencer::newBarrier that allows creating a SequenceBarrier with a particular WaitStrategy.

Rationale: In my project, I need to give particular EventProcessors a backchannel through which other threads can feed it work (e.g., because some data is confined to those EventProcessors or to guarantee ordering with events processed from the RingBuffer). I'm creating a new type of EventProcessor, identical to the BatchEventProcessor except that it calls a callback at the batch boundary. WaitStrategies that are aware of the backchannel return early. Since these backchannels are per EventProcessor, I also need a WaitStrategy per EventProcessor. Right now I have a custom SequenceBarrier as well to tie the WaitStrategy with the EventProcessor, but with this patch I would no longer need to.

Commit 79b5cf7 illustrates what this functionality would look like built into the Disruptor; please let me know what you think.
