### PR TITLE
More generics around usages of ExceptionHandler.java

### DIFF
--- a/src/main/java/com/lmax/disruptor/FatalExceptionHandler.java
+++ b/src/main/java/com/lmax/disruptor/FatalExceptionHandler.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
  * Convenience implementation of an exception handler that using standard JDK logging to log
  * the exception as {@link Level}.SEVERE and re-throw it wrapped in a {@link RuntimeException}
  */
-public final class FatalExceptionHandler implements ExceptionHandler
+public final class FatalExceptionHandler implements ExceptionHandler<Object>
 {
     private static final Logger LOGGER = Logger.getLogger(FatalExceptionHandler.class.getName());
     private final Logger logger;

--- a/src/main/java/com/lmax/disruptor/IgnoreExceptionHandler.java
+++ b/src/main/java/com/lmax/disruptor/IgnoreExceptionHandler.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
  * Convenience implementation of an exception handler that using standard JDK logging to log
  * the exception as {@link Level}.INFO
  */
-public final class IgnoreExceptionHandler implements ExceptionHandler
+public final class IgnoreExceptionHandler implements ExceptionHandler<Object>
 {
     private static final Logger LOGGER = Logger.getLogger(IgnoreExceptionHandler.class.getName());
     private final Logger logger;

--- a/src/main/java/com/lmax/disruptor/WorkProcessor.java
+++ b/src/main/java/com/lmax/disruptor/WorkProcessor.java
@@ -33,7 +33,7 @@ public final class WorkProcessor<T>
     private final RingBuffer<T> ringBuffer;
     private final SequenceBarrier sequenceBarrier;
     private final WorkHandler<? super T> workHandler;
-    private final ExceptionHandler exceptionHandler;
+    private final ExceptionHandler<? super T> exceptionHandler;
     private final Sequence workSequence;
 
     private final EventReleaser eventReleaser = new EventReleaser()
@@ -58,7 +58,7 @@ public final class WorkProcessor<T>
     public WorkProcessor(final RingBuffer<T> ringBuffer,
                          final SequenceBarrier sequenceBarrier,
                          final WorkHandler<? super T> workHandler,
-                         final ExceptionHandler exceptionHandler,
+                         final ExceptionHandler<? super T> exceptionHandler,
                          final Sequence workSequence)
     {
         this.ringBuffer = ringBuffer;

--- a/src/main/java/com/lmax/disruptor/WorkerPool.java
+++ b/src/main/java/com/lmax/disruptor/WorkerPool.java
@@ -47,7 +47,7 @@ public final class WorkerPool<T>
      */
     public WorkerPool(final RingBuffer<T> ringBuffer,
                       final SequenceBarrier sequenceBarrier,
-                      final ExceptionHandler exceptionHandler,
+                      final ExceptionHandler<? super T> exceptionHandler,
                       final WorkHandler<? super T>... workHandlers)
     {
         this.ringBuffer = ringBuffer;
@@ -74,7 +74,7 @@ public final class WorkerPool<T>
      * @param workHandlers to distribute the work load across.
      */
     public WorkerPool(final EventFactory<T> eventFactory,
-                      final ExceptionHandler exceptionHandler,
+                      final ExceptionHandler<? super T> exceptionHandler,
                       final WorkHandler<? super T>... workHandlers)
     {
         ringBuffer = RingBuffer.createMultiProducer(eventFactory, 1024, new BlockingWaitStrategy());

--- a/src/main/java/com/lmax/disruptor/dsl/ConsumerRepository.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ConsumerRepository.java
@@ -22,7 +22,7 @@ import java.util.*;
 /**
  * Provides a repository mechanism to associate {@link EventHandler}s with {@link EventProcessor}s
  *
- * @param T the type of the {@link EventHandler}
+ * @param <T> the type of the {@link EventHandler}
  */
 class ConsumerRepository<T> implements Iterable<ConsumerInfo>
 {
@@ -74,7 +74,7 @@ class ConsumerRepository<T> implements Iterable<ConsumerInfo>
 
     public EventProcessor getEventProcessorFor(final EventHandler<T> handler)
     {
-        final EventProcessorInfo<?> eventprocessorInfo = getEventProcessorInfo(handler);
+        final EventProcessorInfo<T> eventprocessorInfo = getEventProcessorInfo(handler);
         if (eventprocessorInfo == null)
         {
             throw new IllegalArgumentException("The event handler " + handler + " is not processing events.");

--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -62,7 +62,7 @@ public class Disruptor<T>
     private final Executor executor;
     private final ConsumerRepository<T> consumerRepository = new ConsumerRepository<T>();
     private final AtomicBoolean started = new AtomicBoolean(false);
-    private ExceptionHandler exceptionHandler;
+    private ExceptionHandler<? super T> exceptionHandler;
 
     /**
      * Create a new Disruptor. Will default to {@link com.lmax.disruptor.BlockingWaitStrategy} and
@@ -189,7 +189,7 @@ public class Disruptor<T>
      *
      * @param exceptionHandler the exception handler to use for any future {@link EventProcessor}.
      */
-    public void handleExceptionsWith(final ExceptionHandler exceptionHandler)
+    public void handleExceptionsWith(final ExceptionHandler<? super T> exceptionHandler)
     {
         this.exceptionHandler = exceptionHandler;
     }
@@ -201,7 +201,7 @@ public class Disruptor<T>
      * @param eventHandler the event handler to set a different exception handler for.
      * @return an ExceptionHandlerSetting dsl object - intended to be used by chaining the with method call.
      */
-    public ExceptionHandlerSetting<?> handleExceptionsFor(final EventHandler<T> eventHandler)
+    public ExceptionHandlerSetting<T> handleExceptionsFor(final EventHandler<T> eventHandler)
     {
         return new ExceptionHandlerSetting<T>(eventHandler, consumerRepository);
     }

--- a/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerSetting.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerSetting.java
@@ -43,9 +43,9 @@ public class ExceptionHandlerSetting<T>
      *
      * @param exceptionHandler the exception handler to use.
      */
-    public void with(ExceptionHandler exceptionHandler)
+    public void with(ExceptionHandler<? super T> exceptionHandler)
     {
-        ((BatchEventProcessor<?>) consumerRepository.getEventProcessorFor(eventHandler)).setExceptionHandler(exceptionHandler);
+        ((BatchEventProcessor<T>) consumerRepository.getEventProcessorFor(eventHandler)).setExceptionHandler(exceptionHandler);
         consumerRepository.getBarrierFor(eventHandler).alert();
     }
 }

--- a/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
+++ b/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
@@ -47,6 +47,9 @@ public final class BatchEventProcessorTest
         ringBuffer.addGatingSequences(batchEventProcessor.getSequence());
     }
 
+    @SuppressWarnings("unchecked")
+    private final ExceptionHandler<StubEvent> exceptionHandler = context.mock(ExceptionHandler.class);
+
     @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionOnSettingNullExceptionHandler()
     {
@@ -116,7 +119,6 @@ public final class BatchEventProcessorTest
         throws Exception
     {
         final Exception ex = new Exception();
-        final ExceptionHandler exceptionHandler = context.mock(ExceptionHandler.class);
         batchEventProcessor.setExceptionHandler(exceptionHandler);
 
         context.checking(new Expectations()

--- a/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
@@ -52,7 +52,7 @@ public final class FatalExceptionHandlerTest
             }
         });
 
-        ExceptionHandler exceptionHandler = new FatalExceptionHandler(logger);
+        ExceptionHandler<Object> exceptionHandler = new FatalExceptionHandler(logger);
 
         try
         {

--- a/src/test/java/com/lmax/disruptor/IgnoreExceptionHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/IgnoreExceptionHandlerTest.java
@@ -51,7 +51,7 @@ public final class IgnoreExceptionHandlerTest
             }
         });
 
-        ExceptionHandler exceptionHandler = new IgnoreExceptionHandler(logger);
+        ExceptionHandler<Object> exceptionHandler = new IgnoreExceptionHandler(logger);
         exceptionHandler.handleEventException(ex, 0L, event);
     }
 }

--- a/src/test/java/com/lmax/disruptor/dsl/stubs/StubExceptionHandler.java
+++ b/src/test/java/com/lmax/disruptor/dsl/stubs/StubExceptionHandler.java
@@ -19,7 +19,7 @@ import com.lmax.disruptor.ExceptionHandler;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-public class StubExceptionHandler implements ExceptionHandler
+public class StubExceptionHandler implements ExceptionHandler<Object>
 {
     private final AtomicReference<Throwable> exceptionHandled;
 


### PR DESCRIPTION
We've pushed the generics for exception handler around a bit more so that the disruptor<T> and exceptionHandler<T> tie up. 

Things to look out for in your review:
 - we've converted some usages of <?> to <T> 
 - we've convinced ourselves that the cast in ExceptionHandlerSetting  with <T> will work out ok - but this bit felt a little dodgy. 
