### PR TITLE
Add missing DaemonThreadFactory parameter to executor to finish test case

### DIFF
--- a/src/perftest/java/com/lmax/disruptor/queue/OneToThreeDiamondQueueThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/queue/OneToThreeDiamondQueueThroughputTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import com.lmax.disruptor.AbstractPerfTestQueue;
 import com.lmax.disruptor.support.FizzBuzzQueueProcessor;
 import com.lmax.disruptor.support.FizzBuzzStep;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -100,7 +101,7 @@ public final class OneToThreeDiamondQueueThroughputTest extends AbstractPerfTest
     private static final int NUM_EVENT_PROCESSORS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000L * 100L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS, DaemonThreadFactory.INSTANCE);
 
     private final long expectedResult;
     {

--- a/src/perftest/java/com/lmax/disruptor/queue/OneToThreePipelineQueueThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/queue/OneToThreePipelineQueueThroughputTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import com.lmax.disruptor.AbstractPerfTestQueue;
 import com.lmax.disruptor.support.FunctionQueueProcessor;
 import com.lmax.disruptor.support.FunctionStep;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -62,7 +63,7 @@ public final class OneToThreePipelineQueueThroughputTest extends AbstractPerfTes
     private static final int NUM_EVENT_PROCESSORS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000L * 10L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS, DaemonThreadFactory.INSTANCE);
 
     private static final long OPERAND_TWO_INITIAL_VALUE = 777L;
     private final long expectedResult;

--- a/src/perftest/java/com/lmax/disruptor/queue/OneToThreeQueueThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/queue/OneToThreeQueueThroughputTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import com.lmax.disruptor.AbstractPerfTestQueue;
 import com.lmax.disruptor.support.Operation;
 import com.lmax.disruptor.support.ValueMutationQueueProcessor;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -76,7 +77,7 @@ public final class OneToThreeQueueThroughputTest extends AbstractPerfTestQueue
     private static final int NUM_EVENT_PROCESSORS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000L * 1L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS, DaemonThreadFactory.INSTANCE);
 
     private final long[] results = new long[NUM_EVENT_PROCESSORS];
     {

--- a/src/perftest/java/com/lmax/disruptor/queue/ThreeToOneQueueThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/queue/ThreeToOneQueueThroughputTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import com.lmax.disruptor.AbstractPerfTestQueue;
 import com.lmax.disruptor.support.ValueAdditionQueueProcessor;
 import com.lmax.disruptor.support.ValueQueuePublisher;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -73,7 +74,7 @@ public final class ThreeToOneQueueThroughputTest extends AbstractPerfTestQueue
     private static final int NUM_PUBLISHERS = 3;
     private static final int BUFFER_SIZE = 1024 * 64;
     private static final long ITERATIONS = 1000L * 1000L * 20L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_PUBLISHERS + 1);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_PUBLISHERS + 1, DaemonThreadFactory.INSTANCE);
     private final CyclicBarrier cyclicBarrier = new CyclicBarrier(NUM_PUBLISHERS + 1);
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeDiamondSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeDiamondSequencedThroughputTest.java
@@ -30,6 +30,7 @@ import com.lmax.disruptor.YieldingWaitStrategy;
 import com.lmax.disruptor.support.FizzBuzzEvent;
 import com.lmax.disruptor.support.FizzBuzzEventHandler;
 import com.lmax.disruptor.support.FizzBuzzStep;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -81,7 +82,7 @@ public final class OneToThreeDiamondSequencedThroughputTest extends AbstractPerf
     private static final int NUM_EVENT_PROCESSORS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000L * 100L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS, DaemonThreadFactory.INSTANCE);
 
     private final long expectedResult;
     {

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreePipelineSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreePipelineSequencedThroughputTest.java
@@ -30,6 +30,7 @@ import com.lmax.disruptor.YieldingWaitStrategy;
 import com.lmax.disruptor.support.FunctionEvent;
 import com.lmax.disruptor.support.FunctionEventHandler;
 import com.lmax.disruptor.support.FunctionStep;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -72,7 +73,7 @@ public final class OneToThreePipelineSequencedThroughputTest extends AbstractPer
     private static final int NUM_EVENT_PROCESSORS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000L * 100L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS, DaemonThreadFactory.INSTANCE);
 
     private static final long OPERAND_TWO_INITIAL_VALUE = 777L;
     private final long expectedResult;

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeSequencedThroughputTest.java
@@ -30,6 +30,7 @@ import com.lmax.disruptor.YieldingWaitStrategy;
 import com.lmax.disruptor.support.Operation;
 import com.lmax.disruptor.support.ValueEvent;
 import com.lmax.disruptor.support.ValueMutationEventHandler;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -76,7 +77,7 @@ public final class OneToThreeSequencedThroughputTest extends AbstractPerfTestDis
     private static final int NUM_EVENT_PROCESSORS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000L * 100L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_EVENT_PROCESSORS, DaemonThreadFactory.INSTANCE);
 
     private final long[] results = new long[NUM_EVENT_PROCESSORS];
     {

--- a/src/perftest/java/com/lmax/disruptor/sequenced/ThreeToOneSequencedBatchThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/ThreeToOneSequencedBatchThroughputTest.java
@@ -31,6 +31,7 @@ import com.lmax.disruptor.SequenceBarrier;
 import com.lmax.disruptor.support.ValueAdditionEventHandler;
 import com.lmax.disruptor.support.ValueBatchPublisher;
 import com.lmax.disruptor.support.ValueEvent;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -85,7 +86,7 @@ public final class ThreeToOneSequencedBatchThroughputTest extends AbstractPerfTe
     private static final int NUM_PUBLISHERS = 3;
     private static final int BUFFER_SIZE = 1024 * 64;
     private static final long ITERATIONS = 1000L * 1000L * 100L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_PUBLISHERS + 1);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_PUBLISHERS + 1, DaemonThreadFactory.INSTANCE);
     private final CyclicBarrier cyclicBarrier = new CyclicBarrier(NUM_PUBLISHERS + 1);
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeReleasingWorkerPoolThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeReleasingWorkerPoolThroughputTest.java
@@ -27,6 +27,7 @@ import com.lmax.disruptor.WorkerPool;
 import com.lmax.disruptor.YieldingWaitStrategy;
 import com.lmax.disruptor.support.EventCountingAndReleasingWorkHandler;
 import com.lmax.disruptor.support.ValueEvent;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 import com.lmax.disruptor.util.PaddedLong;
 
 public final class OneToThreeReleasingWorkerPoolThroughputTest
@@ -35,7 +36,7 @@ public final class OneToThreeReleasingWorkerPoolThroughputTest
     private static final int NUM_WORKERS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000 * 10L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_WORKERS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_WORKERS, DaemonThreadFactory.INSTANCE);
 
     private final PaddedLong[] counters = new PaddedLong[NUM_WORKERS];
     {

--- a/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeWorkerPoolThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeWorkerPoolThroughputTest.java
@@ -30,6 +30,7 @@ import com.lmax.disruptor.YieldingWaitStrategy;
 import com.lmax.disruptor.support.EventCountingQueueProcessor;
 import com.lmax.disruptor.support.EventCountingWorkHandler;
 import com.lmax.disruptor.support.ValueEvent;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 import com.lmax.disruptor.util.PaddedLong;
 
 public final class OneToThreeWorkerPoolThroughputTest
@@ -38,7 +39,7 @@ public final class OneToThreeWorkerPoolThroughputTest
     private static final int NUM_WORKERS = 3;
     private static final int BUFFER_SIZE = 1024 * 8;
     private static final long ITERATIONS = 1000L * 1000L * 100L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_WORKERS);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_WORKERS, DaemonThreadFactory.INSTANCE);
 
     private final PaddedLong[] counters = new PaddedLong[NUM_WORKERS];
     {

--- a/src/perftest/java/com/lmax/disruptor/workhandler/TwoToTwoWorkProcessorThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/workhandler/TwoToTwoWorkProcessorThroughputTest.java
@@ -33,6 +33,7 @@ import com.lmax.disruptor.WorkProcessor;
 import com.lmax.disruptor.support.ValueAdditionWorkHandler;
 import com.lmax.disruptor.support.ValueEvent;
 import com.lmax.disruptor.support.ValuePublisher;
+import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
  * <pre>
@@ -58,7 +59,7 @@ public final class TwoToTwoWorkProcessorThroughputTest extends AbstractPerfTestD
     private static final int NUM_PUBLISHERS = 2;
     private static final int BUFFER_SIZE = 1024 * 64;
     private static final long ITERATIONS = 1000L * 1000L * 1L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_PUBLISHERS + 2);
+    private final ExecutorService executor = Executors.newFixedThreadPool(NUM_PUBLISHERS + 2, DaemonThreadFactory.INSTANCE);
     private final CyclicBarrier cyclicBarrier = new CyclicBarrier(NUM_PUBLISHERS + 1);
 
     ///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is simple PR to add missing DaemonThreadFactory as parameter of executor to finish test case.