### PR TITLE
Add Disruptor.setDefaultExceptionHandler API

### DIFF
--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -250,7 +250,7 @@ public class Disruptor<T>
         {
             throw new IllegalStateException("Mixing calls to handleExceptionsWith and setDefaultExceptionHandler is not supported.");
         }
-        ((ExceptionHandlerWrapper<T>)this.exceptionHandler).setDelegate(exceptionHandler);
+        ((ExceptionHandlerWrapper<T>)this.exceptionHandler).switchTo(exceptionHandler);
     }
 
     /**

--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -248,7 +248,7 @@ public class Disruptor<T>
         checkNotStarted();
         if (!(this.exceptionHandler instanceof ExceptionHandlerWrapper))
         {
-            throw new IllegalStateException("Mixing calls to handleExceptionsWith and setDefaultExceptionHandler is not supported.");
+            throw new IllegalStateException("setDefaultExceptionHandler can not be used after handleExceptionsWith");
         }
         ((ExceptionHandlerWrapper<T>)this.exceptionHandler).switchTo(exceptionHandler);
     }

--- a/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
@@ -1,0 +1,32 @@
+package com.lmax.disruptor.dsl;
+
+import com.lmax.disruptor.ExceptionHandler;
+import com.lmax.disruptor.FatalExceptionHandler;
+
+public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
+{
+    private ExceptionHandler<? super T> delegate = new FatalExceptionHandler();
+
+    public void setDelegate(final ExceptionHandler<? super T> exceptionHandler)
+    {
+        this.delegate = exceptionHandler;
+    }
+
+    @Override
+    public void handleEventException(final Throwable ex, final long sequence, final T event)
+    {
+        delegate.handleEventException(ex, sequence, event);
+    }
+
+    @Override
+    public void handleOnStartException(final Throwable ex)
+    {
+        delegate.handleOnStartException(ex);
+    }
+
+    @Override
+    public void handleOnShutdownException(final Throwable ex)
+    {
+        delegate.handleOnShutdownException(ex);
+    }
+}

--- a/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
@@ -7,7 +7,7 @@ public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
 {
     private ExceptionHandler<? super T> delegate = new FatalExceptionHandler();
 
-    public void setDelegate(final ExceptionHandler<? super T> exceptionHandler)
+    public void switchTo(final ExceptionHandler<? super T> exceptionHandler)
     {
         this.delegate = exceptionHandler;
     }

--- a/src/test/java/com/lmax/disruptor/DisruptorStressTest.java
+++ b/src/test/java/com/lmax/disruptor/DisruptorStressTest.java
@@ -1,9 +1,8 @@
 package com.lmax.disruptor;
 
-import static java.lang.Math.max;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
+import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -11,10 +10,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.LockSupport;
 
-import org.junit.Test;
-
-import com.lmax.disruptor.dsl.Disruptor;
-import com.lmax.disruptor.dsl.ProducerType;
+import static java.lang.Math.max;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class DisruptorStressTest
 {
@@ -27,7 +26,7 @@ public class DisruptorStressTest
             TestEvent.FACTORY, 1 << 16, executor,
             ProducerType.MULTI, new BusySpinWaitStrategy());
         RingBuffer<TestEvent> ringBuffer = disruptor.getRingBuffer();
-        disruptor.handleExceptionsWith(new FatalExceptionHandler());
+        disruptor.setDefaultExceptionHandler(new FatalExceptionHandler());
 
         int threads = max(1, Runtime.getRuntime().availableProcessors() / 2);
 

--- a/src/test/java/com/lmax/disruptor/ShutdownOnFatalExceptionTest.java
+++ b/src/test/java/com/lmax/disruptor/ShutdownOnFatalExceptionTest.java
@@ -26,7 +26,7 @@ public class ShutdownOnFatalExceptionTest
             new ByteArrayFactory(256), 1024, Executors.newCachedThreadPool(), ProducerType.SINGLE,
             new BlockingWaitStrategy());
         disruptor.handleEventsWith(eventHandler);
-        disruptor.handleExceptionsWith(new FatalExceptionHandler());
+        disruptor.setDefaultExceptionHandler(new FatalExceptionHandler());
     }
 
     @Test(timeout = 1000)


### PR DESCRIPTION
…on handler for all event processors and worker pools created by Disruptor regardless of whether they were created before or after the call to setDefaultExceptionHandler. This fixes #122