### PR TITLE
Integer.highestOneBit() used instead of while loop.

### DIFF
--- a/src/main/java/com/lmax/disruptor/util/Util.java
+++ b/src/main/java/com/lmax/disruptor/util/Util.java
@@ -156,11 +156,6 @@ public final class Util
      */
     public static int log2(int i)
     {
-        int r = 0;
-        while ((i >>= 1) != 0)
-        {
-            ++r;
-        }
-        return r;
+        return Integer.highestOneBit(i);
     }
 }


### PR DESCRIPTION
Both methods run in constant time but highestOneBit does not use any while loop.