### PR TITLE
Short-circuit logic should be used in boolean contexts

### DIFF
--- a/src/main/java/com/lmax/disruptor/EventPoller.java
+++ b/src/main/java/com/lmax/disruptor/EventPoller.java
@@ -53,7 +53,7 @@ public class EventPoller<T>
                     nextSequence++;
 
                 }
-                while (nextSequence <= availableSequence & processNextEvent);
+                while (nextSequence <= availableSequence && processNextEvent);
             }
             finally
             {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S2178 - Short-circuit logic should be used in boolean contexts

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2178
Please let me know if you have any questions.

Kirill Vlasov