### PR TITLE
Add LiteTimeoutBlockingWaitStrategy

### DIFF
--- a/src/main/java/com/lmax/disruptor/LiteTimeoutBlockingWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/LiteTimeoutBlockingWaitStrategy.java
@@ -1,0 +1,83 @@
+package com.lmax.disruptor;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Variation of the {@link TimeoutBlockingWaitStrategy} that attempts to elide conditional wake-ups
+ * when the lock is uncontended.
+ */
+public class LiteTimeoutBlockingWaitStrategy implements WaitStrategy
+{
+    private final Lock lock = new ReentrantLock();
+    private final Condition processorNotifyCondition = lock.newCondition();
+    private final AtomicBoolean signalNeeded = new AtomicBoolean(false);
+    private final long timeoutInNanos;
+
+    public LiteTimeoutBlockingWaitStrategy(final long timeout, final TimeUnit units)
+    {
+        timeoutInNanos = units.toNanos(timeout);
+    }
+
+    @Override
+    public long waitFor(
+        final long sequence,
+        final Sequence cursorSequence,
+        final Sequence dependentSequence,
+        final SequenceBarrier barrier)
+        throws AlertException, InterruptedException, TimeoutException
+    {
+        long nanos = timeoutInNanos;
+
+        long availableSequence;
+        if (cursorSequence.get() < sequence)
+        {
+            lock.lock();
+            try
+            {
+                while (cursorSequence.get() < sequence)
+                {
+                    signalNeeded.getAndSet(true);
+
+                    barrier.checkAlert();
+                    nanos = processorNotifyCondition.awaitNanos(nanos);
+                    if (nanos <= 0)
+                    {
+                        throw TimeoutException.INSTANCE;
+                    }
+                }
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+
+        while ((availableSequence = dependentSequence.get()) < sequence)
+        {
+            barrier.checkAlert();
+        }
+
+        return availableSequence;
+    }
+
+    @Override
+    public void signalAllWhenBlocking()
+    {
+        if (signalNeeded.getAndSet(false))
+        {
+            lock.lock();
+            try
+            {
+                processorNotifyCondition.signalAll();
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/test/java/com/lmax/disruptor/LiteTimeoutBlockingWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/LiteTimeoutBlockingWaitStrategyTest.java
@@ -1,0 +1,54 @@
+package com.lmax.disruptor;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JMock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JMock.class)
+public class LiteTimeoutBlockingWaitStrategyTest
+{
+    private final Mockery mockery = new Mockery();
+
+    @Test
+    public void shouldTimeoutWaitFor() throws Exception
+    {
+        final SequenceBarrier sequenceBarrier = mockery.mock(SequenceBarrier.class);
+
+        long theTimeout = 500;
+        LiteTimeoutBlockingWaitStrategy waitStrategy = new LiteTimeoutBlockingWaitStrategy(theTimeout, TimeUnit.MILLISECONDS);
+        Sequence cursor = new Sequence(5);
+        Sequence dependent = cursor;
+
+        mockery.checking(
+            new Expectations()
+            {
+                {
+                    allowing(sequenceBarrier).checkAlert();
+                }
+            });
+
+        long t0 = System.currentTimeMillis();
+
+        try
+        {
+            waitStrategy.waitFor(6, cursor, dependent, sequenceBarrier);
+            fail("TimeoutException should have been thrown");
+        }
+        catch (TimeoutException e)
+        {
+        }
+
+        long t1 = System.currentTimeMillis();
+
+        long timeWaiting = t1 - t0;
+
+        assertThat(timeWaiting, greaterThanOrEqualTo(theTimeout));
+    }
+}


### PR DESCRIPTION
Log4j 2 uses the TimeoutBlockingWaitStrategy as the default for its Async Loggers (see related issues https://github.com/LMAX-Exchange/disruptor/issues/138 and https://issues.apache.org/jira/browse/LOG4J2-1221 ).

Recent discussion on the Mechanical Sympathy mailing list suggested that some performance improvement may be possible under lower workloads where the consumer thread often falls asleep. In this scenario, if multiple producer threads get additional work they can cooperate in waking up the consumer. Before trying to wake up the consumer, they can first check if another producer has already started to wake up the consumer, and avoid taking the lock if this is the case. This is exactly what the LiteBlockingWaitStrategy does.

This pull request is to add a wait strategy that combines LiteBlockingWaitStrategy with TimeoutBlockingWaitStrategy.

Question: the LiteBlockingWaitStrategy javadoc says that "this wait strategy should be considered experimental as I have not full proved the correctness of the lock elision code". Is this still the case? It looks like the projectreactor.io project used to use this wait strategy. Did they ever give you feedback on any issues with this strategy?