### PR TITLE
Fix bug in factor value check in Histogram

### DIFF
--- a/src/main/java/com/lmax/disruptor/collections/Histogram.java
+++ b/src/main/java/com/lmax/disruptor/collections/Histogram.java
@@ -331,9 +331,9 @@ public final class Histogram
      */
     public long getUpperBoundForFactor(final double factor)
     {
-        if (0.0d >= factor || factor >= 1.0d)
+        if (factor < 0.0d || factor > 1.0d)
         {
-            throw new IllegalArgumentException("factor must be >= 0.0 and <= 1.0");
+            throw new IllegalArgumentException("factor must be > 0.0 and < 1.0");
         }
 
         final long totalCount = getCount();


### PR DESCRIPTION
I've just implemented the value check for the `factor` parameter in `getUpperBoundForFactor` as it was described in the method doc.