### PR TITLE
Proposition: Add a pause after CAS failure in MultiProducerSequencer

### DIFF
--- a/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
@@ -144,6 +144,10 @@ public final class MultiProducerSequencer extends AbstractSequencer
             {
                 break;
             }
+            else
+            {
+                LockSupport.parkNanos(1);
+            }
         }
         while (true);
 


### PR DESCRIPTION
While analyzing the performance of the .NET port of the Disruptor, I noticed that the CAS in MultiProducerSequencer was the main contention point for 3P1C scenarios. The aggressive busy-spin on the CAS seems to be harm the overall throughput.

By adding a pause with `LockSupport.parkNanos(1)` when the CAS fails I was able to improve the throughput of 3P1C scenarios. On my machine, the ops/sec for ThreeToOneSequencedThroughputTest increase from about 13M to about 21M. The ThreeToOneSequencedBatchThroughputTest performance was also improved. I did not see any change in the other scenarios.

However this pause might have a negative impact on the fairness of the sequencer, or on the max latencies.

What are your thoughts?