### PR TITLE
Don't add processor twice

### DIFF
--- a/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
@@ -338,8 +338,8 @@ public class DisruptorTest
 
         final BatchEventProcessor<TestEvent> processor =
             new BatchEventProcessor<TestEvent>(ringBuffer, ringBuffer.newBarrier(), delayedEventHandler);
-        disruptor.handleEventsWith(processor);
-        disruptor.after(processor).handleEventsWith(handlerWithBarrier);
+
+        disruptor.handleEventsWith(processor).then(handlerWithBarrier);
 
         ensureTwoEventsProcessedAccordingToDependencies(countDownLatch, delayedEventHandler);
     }


### PR DESCRIPTION
The BatchEventProcessor throws an exception as it has already been started.