### PR TITLE
Fix initial CountDownLatch value in test

### DIFF
--- a/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
@@ -96,7 +96,7 @@ public class DisruptorTest
     @Test
     public void shouldProcessMessagesPublishedBeforeStartIsCalled() throws Exception
     {
-        final CountDownLatch eventCounter = new CountDownLatch(0);
+        final CountDownLatch eventCounter = new CountDownLatch(2);
         disruptor.handleEventsWith(new EventHandler<TestEvent>()
         {
             @Override


### PR DESCRIPTION
The test `shouldProcessMessagesPublishedBeforeStartIsCalled` is not testing anything because the initial `CountDownLatch` value is zero.