### PR TITLE
Notify BatchStartAware event handlers of batch size before processing…

### DIFF
--- a/src/main/java/com/lmax/disruptor/BatchStartAware.java
+++ b/src/main/java/com/lmax/disruptor/BatchStartAware.java
@@ -1,0 +1,6 @@
+package com.lmax.disruptor;
+
+public interface BatchStartAware
+{
+    void onBatchStart(final long batchSize);
+}


### PR DESCRIPTION
… a batch in BatchEventProcessor

Motivation:

The event handler may wish to change its behaviour if the batch size is large.

For example: Imagine a situation where:

- the events being sent are coalesceable in some way
- the processing of each event is potentially expensive. 

If the event handler knows, before a batch is processed, that the batch is large (and therefore the opportunity to coalesce is high) it can switch to a coalescing mode prior to batch processing, coalesce whatever events in the batch and then perform the necessary processing on a much smaller set of events at batch end. This should save cpu time and hopefully help make future batches smaller.

Another example: Monitoring - a large batch is a potentially useful performance metric. At the moment, we can detect large batches by being mildly clever and detecting batch end; it'd be nice to know the metric at the start of the batch, though.

Notes:

This doesn't have to go in disruptor, but it would be handy to not have to reproduce the entirety of BatchEventProcessor in order to do it.

I haven't written any tests (even with BEP's interface I think we should be able to write at least one...) - I wanted to get an opinion on whether this is going to fly or not first :-)