### PR TITLE
Fixed a broken link to the technical paper.

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
             <li><a href="http://blogs.lmax.com/">LMAX</a> (Planet)</li>
             <li><a href="http://www.lmax.com">LMAX Exchange</a></li>
             <li><a href="http://www.infoq.com/presentations/LMAX">Disruptor presentation @ QCon SF</a></li>
-            <li><a href="http://disruptor.googlecode.com/files/Disruptor-1.0.pdf">Disruptor Technical Paper</a></li>
+            <li><a href="http://lmax-exchange.github.com/disruptor/files/Disruptor-1.0.pdf">Disruptor Technical Paper</a></li>
             <li><a href="http://mechanical-sympathy.blogspot.com">Mechanical Sympathy</a> (Martin Thompson)</li>
             <li><a href="http://martinfowler.com/articles/lmax.html">Martin Fowler's Technical Review</a></li>
             <li><a href="https://github.com/odeheurles/Disruptor-net">.NET Disruptor Port</a></li>


### PR DESCRIPTION
The link to the technical paper in the main link section is broken.
Luckily a valid link appears just below, so the fix is trivial.