### PR TITLE
Added sliced on heap ByteBuffer test

### DIFF
--- a/runoffheap.sh
+++ b/runoffheap.sh
@@ -14,4 +14,8 @@ echo "Done"
 echo "Running OnHeap..."
 $BIN $ARGS $GCARGS -Xloggc:custom-gc.log $CPATH com.lmax.disruptor.offheap.OneToOneOnHeapThroughputTest
 echo "Done"
+
+echo "Running Sliced OnHeap..."
+$BIN $ARGS $GCARGS -Xloggc:custom-gc.log $CPATH -Dsliced=true com.lmax.disruptor.offheap.OneToOneOnHeapThroughputTest
+echo "Done"
      

--- a/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
@@ -1,20 +1,15 @@
 package com.lmax.disruptor.offheap;
 
+import com.lmax.disruptor.*;
+import com.lmax.disruptor.util.DaemonThreadFactory;
+
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.LockSupport;
-
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.BatchEventProcessor;
-import com.lmax.disruptor.EventFactory;
-import com.lmax.disruptor.EventHandler;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.WaitStrategy;
-import com.lmax.disruptor.YieldingWaitStrategy;
-import com.lmax.disruptor.util.DaemonThreadFactory;
 
 public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
 {
@@ -22,11 +17,14 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
     private static final int BUFFER_SIZE = 1024 * 1024;
     private static final long ITERATIONS = 1000 * 1000 * 10L;
 
+    private static final boolean SLICED_BUFFER = Boolean.getBoolean("sliced");
     private final Executor executor = Executors.newFixedThreadPool(1, DaemonThreadFactory.INSTANCE);
     private final WaitStrategy waitStrategy = new YieldingWaitStrategy();
     private final RingBuffer<ByteBuffer> buffer =
-        RingBuffer.createSingleProducer(BufferFactory.direct(BLOCK_SIZE), BUFFER_SIZE, waitStrategy);
-    private final ByteBufferHandler handler = new ByteBufferHandler();
+        RingBuffer.createSingleProducer(
+            SLICED_BUFFER ? SlicedBufferFactory.direct(BLOCK_SIZE, BUFFER_SIZE) : BufferFactory.direct(BLOCK_SIZE),
+            BUFFER_SIZE, waitStrategy);
+        private final ByteBufferHandler handler = new ByteBufferHandler();
     private final BatchEventProcessor<ByteBuffer> processor =
         new BatchEventProcessor<ByteBuffer>(buffer, buffer.newBarrier(), handler);
 
@@ -103,7 +101,7 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
         {
             for (int i = 0; i < BLOCK_SIZE; i += 8)
             {
-                total += event.getLong();
+                total += event.getLong(i);
             }
 
             if (--expectedCount == 0)
@@ -140,11 +138,11 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
         {
             if (isDirect)
             {
-                return ByteBuffer.allocateDirect(size);
+                return ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder());
             }
             else
             {
-                return ByteBuffer.allocate(size);
+                return ByteBuffer.allocate(size).order(ByteOrder.nativeOrder());
             }
         }
 
@@ -157,6 +155,53 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
         public static BufferFactory heap(int size)
         {
             return new BufferFactory(false, size);
+        }
+    }
+
+    private static final class SlicedBufferFactory implements EventFactory<ByteBuffer>
+    {
+        private final boolean isDirect;
+        private final int size;
+        private final int total;
+        private ByteBuffer buffer;
+
+        private SlicedBufferFactory(boolean isDirect, int size, int total)
+        {
+            this.isDirect = isDirect;
+            this.size = size;
+            this.total = total;
+            this.buffer =
+                (isDirect ? ByteBuffer.allocateDirect(size * total) : ByteBuffer.allocate(size * total))
+                    .order(ByteOrder.nativeOrder());
+            this.buffer.limit(0);
+        }
+
+        @Override
+        public ByteBuffer newInstance()
+        {
+            if (this.buffer.limit() == this.buffer.capacity())
+            {
+                this.buffer =
+                    (isDirect ? ByteBuffer.allocateDirect(size * total) : ByteBuffer.allocate(size * total))
+                        .order(ByteOrder.nativeOrder());
+                this.buffer.limit(0);
+            }
+            final int limit = this.buffer.limit();
+            this.buffer.limit(limit + size);
+            this.buffer.position(limit);
+            final ByteBuffer slice = this.buffer.slice().order(ByteOrder.nativeOrder());
+            return slice;
+        }
+
+        public static SlicedBufferFactory direct(int size, int total)
+        {
+            return new SlicedBufferFactory(true, size, total);
+        }
+
+        @SuppressWarnings("unused")
+        public static SlicedBufferFactory heap(int size, int total)
+        {
+            return new SlicedBufferFactory(false, size, total);
         }
     }
 }


### PR DESCRIPTION
To better isolate the benefits of having a contiguos off heap ringbuffer directly referenced (ie `OneToOneOffHeapThroughputTest`) I've added the on heap case where the ring buffer slots are slices of the same contiguos buffer.

In addition I've used `ByteOrder::nativeOrder()` for all the buffers and `ByteBuffer::getLong(idx)`.
Now the differences (on my box at least) are very different from the original test!
