### PR TITLE
Add batch size to performance tests

### DIFF
--- a/src/perftest/java/com/lmax/disruptor/AbstractPerfTestDisruptor.java
+++ b/src/perftest/java/com/lmax/disruptor/AbstractPerfTestDisruptor.java
@@ -16,8 +16,6 @@
 package com.lmax.disruptor;
 
 
-import sun.misc.Perf;
-
 public abstract class AbstractPerfTestDisruptor
 {
     public static final int RUNS = 7;
@@ -25,7 +23,8 @@ public abstract class AbstractPerfTestDisruptor
     protected void testImplementations()
         throws Exception {
         final int availableProcessors = Runtime.getRuntime().availableProcessors();
-        if (getRequiredProcessorCount() > availableProcessors) {
+        if (getRequiredProcessorCount() > availableProcessors)
+        {
             System.out.print("*** Warning ***: your system has insufficient processors to execute the test efficiently. ");
             System.out.println("Processors required = " + getRequiredProcessorCount() + " available = " + availableProcessors);
         }
@@ -33,7 +32,8 @@ public abstract class AbstractPerfTestDisruptor
         PerfTestContext[] contexts = new PerfTestContext[RUNS];
 
         System.out.println("Starting Disruptor tests");
-        for (int i = 0; i < RUNS; i++) {
+        for (int i = 0; i < RUNS; i++)
+        {
             System.gc();
             PerfTestContext context = runDisruptorPass();
             contexts[i] = context;
@@ -48,7 +48,8 @@ public abstract class AbstractPerfTestDisruptor
         {
             PerfTestContext context = contexts[i];
             System.out.format("%s run %d: BlockingQueue=%,d Disruptor=%,d ops/sec BatchPercent=%,d AverageBatchSize=%,d\n",
-                              className, Integer.valueOf(i), Long.valueOf(queueOps[i]), Long.valueOf(context.getDisruptorOps()), Double.valueOf(context.getBatchPercent()), Double.valueOf(context.getAverageBatchSize()));
+                              className, Integer.valueOf(i), Long.valueOf(queueOps[i]), Long.valueOf(context.getDisruptorOps()),
+                              Double.valueOf(context.getBatchPercent()), Double.valueOf(context.getAverageBatchSize()));
         }
     }
 

--- a/src/perftest/java/com/lmax/disruptor/AbstractPerfTestDisruptor.java
+++ b/src/perftest/java/com/lmax/disruptor/AbstractPerfTestDisruptor.java
@@ -16,41 +16,44 @@
 package com.lmax.disruptor;
 
 
+import sun.misc.Perf;
+
 public abstract class AbstractPerfTestDisruptor
 {
     public static final int RUNS = 7;
 
     protected void testImplementations()
-        throws Exception
-    {
+        throws Exception {
         final int availableProcessors = Runtime.getRuntime().availableProcessors();
-        if (getRequiredProcessorCount() > availableProcessors)
-        {
+        if (getRequiredProcessorCount() > availableProcessors) {
             System.out.print("*** Warning ***: your system has insufficient processors to execute the test efficiently. ");
             System.out.println("Processors required = " + getRequiredProcessorCount() + " available = " + availableProcessors);
         }
 
-        long[] disruptorOps = new long[RUNS];
+        PerfTestContext[] contexts = new PerfTestContext[RUNS];
 
         System.out.println("Starting Disruptor tests");
-        for (int i = 0; i < RUNS; i++)
-        {
+        for (int i = 0; i < RUNS; i++) {
             System.gc();
-            disruptorOps[i] = runDisruptorPass();
-            System.out.format("Run %d, Disruptor=%,d ops/sec%n", i, Long.valueOf(disruptorOps[i]));
+            PerfTestContext context = runDisruptorPass();
+            contexts[i] = context;
+            System.out.format("Run %d, Disruptor=%,d ops/sec BatchPercent=%.2f%% AverageBatchSize=%,d\n",
+                    i, context.getDisruptorOps(), context.getBatchPercent() * 100, (long)context.getAverageBatchSize());
         }
     }
 
-    public static void printResults(final String className, final long[] disruptorOps, final long[] queueOps)
+    public static void printResults(final String className, final PerfTestContext[] contexts, final long[] queueOps)
     {
         for (int i = 0; i < RUNS; i++)
         {
-            System.out.format("%s run %d: BlockingQueue=%,d Disruptor=%,d ops/sec\n",
-                              className, Integer.valueOf(i), Long.valueOf(queueOps[i]), Long.valueOf(disruptorOps[i]));
+            PerfTestContext context = contexts[i];
+            System.out.format("%s run %d: BlockingQueue=%,d Disruptor=%,d ops/sec BatchPercent=%,d AverageBatchSize=%,d\n",
+                              className, Integer.valueOf(i), Long.valueOf(queueOps[i]), Long.valueOf(context.getDisruptorOps()), Double.valueOf(context.getBatchPercent()), Double.valueOf(context.getAverageBatchSize()));
         }
     }
 
     protected abstract int getRequiredProcessorCount();
 
-    protected abstract long runDisruptorPass() throws Exception;
+    protected abstract PerfTestContext runDisruptorPass() throws Exception;
 }
+

--- a/src/perftest/java/com/lmax/disruptor/AbstractPerfTestDisruptor.java
+++ b/src/perftest/java/com/lmax/disruptor/AbstractPerfTestDisruptor.java
@@ -21,7 +21,8 @@ public abstract class AbstractPerfTestDisruptor
     public static final int RUNS = 7;
 
     protected void testImplementations()
-        throws Exception {
+        throws Exception
+    {
         final int availableProcessors = Runtime.getRuntime().availableProcessors();
         if (getRequiredProcessorCount() > availableProcessors)
         {

--- a/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
+++ b/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
@@ -1,6 +1,7 @@
 package com.lmax.disruptor;
 
-public class PerfTestContext {
+public class PerfTestContext
+{
     private long disruptorOps;
     private long batchesProcessedCount;
     private long iterations;
@@ -9,15 +10,18 @@ public class PerfTestContext {
     {
     }
 
-    public long getDisruptorOps() {
+    public long getDisruptorOps()
+    {
         return disruptorOps;
     }
 
-    public void setDisruptorOps(long disruptorOps) {
+    public void setDisruptorOps(long disruptorOps)
+    {
         this.disruptorOps = disruptorOps;
     }
 
-    public long getBatchesProcessedCount() {
+    public long getBatchesProcessedCount()
+    {
         return batchesProcessedCount;
     }
 

--- a/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
+++ b/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
@@ -5,7 +5,8 @@ public class PerfTestContext {
     private long batchesProcessedCount;
     private long iterations;
 
-    public PerfTestContext() {
+    public PerfTestContext()
+    {
     }
 
     public long getDisruptorOps() {
@@ -20,17 +21,20 @@ public class PerfTestContext {
         return batchesProcessedCount;
     }
 
-    public double getBatchPercent() {
+    public double getBatchPercent()
+    {
         if (batchesProcessedCount == 0) return 0;
         return 1 - (double)batchesProcessedCount / iterations;
     }
 
-    public double getAverageBatchSize() {
+    public double getAverageBatchSize()
+    {
         if (batchesProcessedCount == 0) return -1;
         return (double)iterations / batchesProcessedCount;
     }
 
-    public void setBatchData(long batchesProcessedCount, long iterations) {
+    public void setBatchData(long batchesProcessedCount, long iterations)
+    {
         this.batchesProcessedCount = batchesProcessedCount;
         this.iterations = iterations;
     }

--- a/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
+++ b/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
@@ -21,6 +21,7 @@ public class PerfTestContext {
     }
 
     public double getBatchPercent() {
+        if (batchesProcessedCount == 0) return 0;
         return 1 - (double)batchesProcessedCount / iterations;
     }
 

--- a/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
+++ b/src/perftest/java/com/lmax/disruptor/PerfTestContext.java
@@ -1,0 +1,36 @@
+package com.lmax.disruptor;
+
+public class PerfTestContext {
+    private long disruptorOps;
+    private long batchesProcessedCount;
+    private long iterations;
+
+    public PerfTestContext() {
+    }
+
+    public long getDisruptorOps() {
+        return disruptorOps;
+    }
+
+    public void setDisruptorOps(long disruptorOps) {
+        this.disruptorOps = disruptorOps;
+    }
+
+    public long getBatchesProcessedCount() {
+        return batchesProcessedCount;
+    }
+
+    public double getBatchPercent() {
+        return 1 - (double)batchesProcessedCount / iterations;
+    }
+
+    public double getAverageBatchSize() {
+        if (batchesProcessedCount == 0) return -1;
+        return (double)iterations / batchesProcessedCount;
+    }
+
+    public void setBatchData(long batchesProcessedCount, long iterations) {
+        this.batchesProcessedCount = batchesProcessedCount;
+        this.iterations = iterations;
+    }
+}

--- a/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOffHeapThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOffHeapThroughputTest.java
@@ -111,7 +111,11 @@ public class OneToOneOffHeapThroughputTest extends AbstractPerfTestDisruptor
         {
             return total.get();
         }
-        public long getBatchesProcessed() { return batchesProcessed.get(); }
+
+        public long getBatchesProcessed()
+        {
+            return batchesProcessed.get();
+        }
 
         public void reset(CountDownLatch latch, long expectedCount)
         {

--- a/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOffHeapThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOffHeapThroughputTest.java
@@ -85,7 +85,7 @@ public class OneToOneOffHeapThroughputTest extends AbstractPerfTestDisruptor
         new OneToOneOffHeapThroughputTest().testImplementations();
     }
 
-    public static class ByteBufferHandler implements EventHandler<ByteBuffer>
+    public static class ByteBufferHandler implements EventHandler<ByteBuffer>, BatchStartAware
     {
         private final PaddedLong total = new PaddedLong();
         private final PaddedLong batchesProcessed = new PaddedLong();
@@ -99,11 +99,6 @@ public class OneToOneOffHeapThroughputTest extends AbstractPerfTestDisruptor
             for (int i = start, size = start + BLOCK_SIZE; i < size; i += 8)
             {
                 total.set(total.get() + event.getLong(i));
-            }
-
-            if (endOfBatch)
-            {
-                batchesProcessed.increment();
             }
 
             if (--expectedCount == 0)
@@ -124,6 +119,12 @@ public class OneToOneOffHeapThroughputTest extends AbstractPerfTestDisruptor
             this.expectedCount = expectedCount;
             this.total.set(0);
             this.batchesProcessed.set(0);
+        }
+
+        @Override
+        public void onBatchStart(long batchSize)
+        {
+            batchesProcessed.increment();
         }
     }
 

--- a/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
@@ -118,7 +118,11 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
         {
             return total.get();
         }
-        public long getBatchesProcessed() { return batchesProcessed.get(); }
+
+        public long getBatchesProcessed()
+        {
+            return batchesProcessed.get();
+        }
 
         public void reset(CountDownLatch latch, long expectedCount)
         {

--- a/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
@@ -93,7 +93,7 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
         new OneToOneOnHeapThroughputTest().testImplementations();
     }
 
-    public static class ByteBufferHandler implements EventHandler<ByteBuffer>
+    public static class ByteBufferHandler implements EventHandler<ByteBuffer>, BatchStartAware
     {
         private final PaddedLong total = new PaddedLong();
         private final PaddedLong batchesProcessed = new PaddedLong();
@@ -106,11 +106,6 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
             for (int i = 0; i < BLOCK_SIZE; i += 8)
             {
                 total.set(total.get() + event.getLong(i));
-            }
-
-            if (endOfBatch)
-            {
-                batchesProcessed.increment();
             }
 
             if (--expectedCount == 0)
@@ -131,6 +126,12 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
             this.expectedCount = expectedCount;
             this.total.set(0);
             this.batchesProcessed.set(0);
+        }
+
+        @Override
+        public void onBatchStart(long batchSize)
+        {
+            batchesProcessed.increment();
         }
     }
 

--- a/src/perftest/java/com/lmax/disruptor/raw/OneToOneRawBatchThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/raw/OneToOneRawBatchThroughputTest.java
@@ -19,13 +19,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.Sequence;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.Sequenced;
-import com.lmax.disruptor.Sequencer;
-import com.lmax.disruptor.SingleProducerSequencer;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
@@ -95,8 +89,9 @@ public final class OneToOneRawBatchThroughputTest extends AbstractPerfTestDisrup
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         int batchSize = 10;
         final CountDownLatch latch = new CountDownLatch(1);
         long expectedCount = myRunnable.sequence.get() + (ITERATIONS * batchSize);
@@ -114,10 +109,10 @@ public final class OneToOneRawBatchThroughputTest extends AbstractPerfTestDisrup
 
         latch.await();
         long end = System.currentTimeMillis();
-        long opsPerSecond = (ITERATIONS * 1000L * batchSize) / (end - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L * batchSize) / (end - start));
         waitForEventProcessorSequence(expectedCount);
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     private void waitForEventProcessorSequence(long expectedCount) throws InterruptedException

--- a/src/perftest/java/com/lmax/disruptor/raw/OneToOneRawThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/raw/OneToOneRawThroughputTest.java
@@ -19,13 +19,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.Sequence;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.Sequenced;
-import com.lmax.disruptor.Sequencer;
-import com.lmax.disruptor.SingleProducerSequencer;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.util.DaemonThreadFactory;
 
 /**
@@ -95,8 +89,9 @@ public final class OneToOneRawThroughputTest extends AbstractPerfTestDisruptor
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         final CountDownLatch latch = new CountDownLatch(1);
         long expectedCount = myRunnable.sequence.get() + ITERATIONS;
         myRunnable.reset(latch, expectedCount);
@@ -112,10 +107,10 @@ public final class OneToOneRawThroughputTest extends AbstractPerfTestDisruptor
         }
 
         latch.await();
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
         waitForEventProcessorSequence(expectedCount);
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     private void waitForEventProcessorSequence(long expectedCount) throws InterruptedException

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedBatchThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedBatchThroughputTest.java
@@ -22,11 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.BatchEventProcessor;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.PerfTestUtil;
 import com.lmax.disruptor.support.ValueAdditionEventHandler;
 import com.lmax.disruptor.support.ValueEvent;
@@ -91,8 +87,9 @@ public final class OneToOneSequencedBatchThroughputTest extends AbstractPerfTest
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         final CountDownLatch latch = new CountDownLatch(1);
         long expectedCount = batchEventProcessor.getSequence().get() + ITERATIONS * BATCH_SIZE;
         handler.reset(latch, expectedCount);
@@ -113,13 +110,14 @@ public final class OneToOneSequencedBatchThroughputTest extends AbstractPerfTest
         }
 
         latch.await();
-        long opsPerSecond = (BATCH_SIZE * ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((BATCH_SIZE * ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
+        perfTestContext.setBatchData(handler.getBatchesProcessed(), ITERATIONS);
         waitForEventProcessorSequence(expectedCount);
         batchEventProcessor.halt();
 
         failIfNot(expectedResult, handler.getValue());
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     private void waitForEventProcessorSequence(long expectedCount) throws InterruptedException

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedPollerThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedPollerThroughputTest.java
@@ -149,7 +149,11 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
         {
             return value.get();
         }
-        public long getBatchesProcessed() { return batchesProcessed.get(); }
+
+        public long getBatchesProcessed()
+        {
+            return batchesProcessed.get();
+        }
 
         @Override
         public void onBatchStart(long batchSize)

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedPollerThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedPollerThroughputTest.java
@@ -85,7 +85,7 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
         return 2;
     }
 
-    private static class PollRunnable implements Runnable, EventPoller.Handler<ValueEvent>
+    private static class PollRunnable implements Runnable, EventPoller.Handler<ValueEvent>, BatchStartAware
     {
         private final EventPoller<ValueEvent> poller;
         private volatile boolean running = true;
@@ -123,11 +123,6 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
         {
             value.set(value.get() + event.getValue());
 
-            if (endOfBatch)
-            {
-                batchesProcessed.increment();
-            }
-
             if (count == sequence)
             {
                 latch.countDown();
@@ -155,6 +150,12 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
             return value.get();
         }
         public long getBatchesProcessed() { return batchesProcessed.get(); }
+
+        @Override
+        public void onBatchStart(long batchSize)
+        {
+            batchesProcessed.increment();
+        }
     }
 
     @Override

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedPollerThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedPollerThroughputTest.java
@@ -22,11 +22,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.EventPoller;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.EventPoller.PollState;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.YieldingWaitStrategy;
 import com.lmax.disruptor.support.PerfTestUtil;
 import com.lmax.disruptor.support.ValueEvent;
 import com.lmax.disruptor.util.DaemonThreadFactory;
@@ -93,6 +90,7 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
         private final EventPoller<ValueEvent> poller;
         private volatile boolean running = true;
         private final PaddedLong value = new PaddedLong();
+        private final PaddedLong batchesProcessed = new PaddedLong();
         private CountDownLatch latch;
         private long count;
 
@@ -125,6 +123,11 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
         {
             value.set(value.get() + event.getValue());
 
+            if (endOfBatch)
+            {
+                batchesProcessed.increment();
+            }
+
             if (count == sequence)
             {
                 latch.countDown();
@@ -143,6 +146,7 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
             value.set(0L);
             this.latch = latch;
             count = expectedCount;
+            batchesProcessed.set(0);
             running = true;
         }
 
@@ -150,11 +154,13 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
         {
             return value.get();
         }
+        public long getBatchesProcessed() { return batchesProcessed.get(); }
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         final CountDownLatch latch = new CountDownLatch(1);
         long expectedCount = poller.getSequence().get() + ITERATIONS;
         pollRunnable.reset(latch, expectedCount);
@@ -171,13 +177,14 @@ public final class OneToOneSequencedPollerThroughputTest extends AbstractPerfTes
         }
 
         latch.await();
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
+        perfTestContext.setBatchData(pollRunnable.getBatchesProcessed(), ITERATIONS);
         waitForEventProcessorSequence(expectedCount);
         pollRunnable.halt();
 
         failIfNot(expectedResult, pollRunnable.getValue());
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     private void waitForEventProcessorSequence(long expectedCount) throws InterruptedException

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeDiamondSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeDiamondSequencedThroughputTest.java
@@ -22,11 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.BatchEventProcessor;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.FizzBuzzEvent;
 import com.lmax.disruptor.support.FizzBuzzEventHandler;
 import com.lmax.disruptor.support.FizzBuzzStep;
@@ -138,8 +134,9 @@ public final class OneToThreeDiamondSequencedThroughputTest extends AbstractPerf
     }
 
     @Override
-    protected long runDisruptorPass() throws Exception
+    protected PerfTestContext runDisruptorPass() throws Exception
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         CountDownLatch latch = new CountDownLatch(1);
         fizzBuzzHandler.reset(latch, batchProcessorFizzBuzz.getSequence().get() + ITERATIONS);
 
@@ -157,7 +154,7 @@ public final class OneToThreeDiamondSequencedThroughputTest extends AbstractPerf
         }
 
         latch.await();
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
 
         batchProcessorFizz.halt();
         batchProcessorBuzz.halt();
@@ -165,7 +162,7 @@ public final class OneToThreeDiamondSequencedThroughputTest extends AbstractPerf
 
         failIfNot(expectedResult, fizzBuzzHandler.getFizzBuzzCounter());
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     public static void main(String[] args) throws Exception

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreePipelineSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreePipelineSequencedThroughputTest.java
@@ -22,11 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.BatchEventProcessor;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.FunctionEvent;
 import com.lmax.disruptor.support.FunctionEventHandler;
 import com.lmax.disruptor.support.FunctionStep;
@@ -129,8 +125,10 @@ public final class OneToThreePipelineSequencedThroughputTest extends AbstractPer
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
+
         CountDownLatch latch = new CountDownLatch(1);
         stepThreeFunctionHandler.reset(latch, stepThreeBatchProcessor.getSequence().get() + ITERATIONS);
 
@@ -151,7 +149,7 @@ public final class OneToThreePipelineSequencedThroughputTest extends AbstractPer
         }
 
         latch.await();
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
 
         stepOneBatchProcessor.halt();
         stepTwoBatchProcessor.halt();
@@ -159,7 +157,7 @@ public final class OneToThreePipelineSequencedThroughputTest extends AbstractPer
 
         failIfNot(expectedResult, stepThreeFunctionHandler.getStepThreeCounter());
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     public static void main(String[] args) throws Exception

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeSequencedThroughputTest.java
@@ -22,11 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.BatchEventProcessor;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.Operation;
 import com.lmax.disruptor.support.ValueEvent;
 import com.lmax.disruptor.support.ValueMutationEventHandler;
@@ -127,8 +123,9 @@ public final class OneToThreeSequencedThroughputTest extends AbstractPerfTestDis
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         CountDownLatch latch = new CountDownLatch(NUM_EVENT_PROCESSORS);
         for (int i = 0; i < NUM_EVENT_PROCESSORS; i++)
         {
@@ -146,14 +143,23 @@ public final class OneToThreeSequencedThroughputTest extends AbstractPerfTestDis
         }
 
         latch.await();
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
+        perfTestContext.setBatchData(sumBatches(handlers), ITERATIONS * handlers.length);
         for (int i = 0; i < NUM_EVENT_PROCESSORS; i++)
         {
             batchEventProcessors[i].halt();
             failIfNot(results[i], handlers[i].getValue());
         }
 
-        return opsPerSecond;
+        return perfTestContext;
+    }
+
+    private long sumBatches(ValueMutationEventHandler[] handlers) {
+        long sum = 0;
+        for (ValueMutationEventHandler handler : handlers) {
+            sum += handler.getBatchesProcessed();
+        }
+        return sum;
     }
 
     public static void main(String[] args) throws Exception

--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToThreeSequencedThroughputTest.java
@@ -154,9 +154,11 @@ public final class OneToThreeSequencedThroughputTest extends AbstractPerfTestDis
         return perfTestContext;
     }
 
-    private long sumBatches(ValueMutationEventHandler[] handlers) {
+    private long sumBatches(ValueMutationEventHandler[] handlers)
+    {
         long sum = 0;
-        for (ValueMutationEventHandler handler : handlers) {
+        for (ValueMutationEventHandler handler : handlers)
+        {
             sum += handler.getBatchesProcessed();
         }
         return sum;

--- a/src/perftest/java/com/lmax/disruptor/sequenced/ThreeToOneSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/ThreeToOneSequencedThroughputTest.java
@@ -23,11 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.BatchEventProcessor;
-import com.lmax.disruptor.BusySpinWaitStrategy;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.SequenceBarrier;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.ValueAdditionEventHandler;
 import com.lmax.disruptor.support.ValueEvent;
 import com.lmax.disruptor.support.ValuePublisher;
@@ -116,8 +112,9 @@ public final class ThreeToOneSequencedThroughputTest extends AbstractPerfTestDis
     }
 
     @Override
-    protected long runDisruptorPass() throws Exception
+    protected PerfTestContext runDisruptorPass() throws Exception
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         final CountDownLatch latch = new CountDownLatch(1);
         handler
             .reset(latch, batchEventProcessor.getSequence().get() + ((ITERATIONS / NUM_PUBLISHERS) * NUM_PUBLISHERS));
@@ -139,10 +136,11 @@ public final class ThreeToOneSequencedThroughputTest extends AbstractPerfTestDis
 
         latch.await();
 
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
+        perfTestContext.setBatchData(handler.getBatchesProcessed(), ITERATIONS);
         batchEventProcessor.halt();
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     public static void main(String[] args) throws Exception

--- a/src/perftest/java/com/lmax/disruptor/sequenced/ThreeToThreeSequencedThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/ThreeToThreeSequencedThroughputTest.java
@@ -21,11 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.EventFactory;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.LongArrayEventHandler;
 import com.lmax.disruptor.support.LongArrayPublisher;
 import com.lmax.disruptor.support.MultiBufferBatchEventProcessor;
@@ -121,8 +117,9 @@ public final class ThreeToThreeSequencedThroughputTest extends AbstractPerfTestD
     }
 
     @Override
-    protected long runDisruptorPass() throws Exception
+    protected PerfTestContext runDisruptorPass() throws Exception
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         final CountDownLatch latch = new CountDownLatch(1);
         handler.reset(latch, ITERATIONS);
 
@@ -143,10 +140,11 @@ public final class ThreeToThreeSequencedThroughputTest extends AbstractPerfTestD
 
         latch.await();
 
-        long opsPerSecond = (ITERATIONS * 1000L * ARRAY_SIZE) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L * ARRAY_SIZE) / (System.currentTimeMillis() - start));
+        perfTestContext.setBatchData(handler.getBatchesProcessed(), ITERATIONS * ARRAY_SIZE);
         batchEventProcessor.halt();
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     public static void main(String[] args) throws Exception

--- a/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
@@ -23,6 +23,7 @@ import com.lmax.disruptor.util.PaddedLong;
 public final class LongArrayEventHandler implements EventHandler<long[]>
 {
     private final PaddedLong value = new PaddedLong();
+    private final PaddedLong batchesProcessed = new PaddedLong();
     private long count;
     private CountDownLatch latch;
 
@@ -30,12 +31,14 @@ public final class LongArrayEventHandler implements EventHandler<long[]>
     {
         return value.get();
     }
+    public long getBatchesProcessed() { return batchesProcessed.get(); }
 
     public void reset(final CountDownLatch latch, final long expectedCount)
     {
         value.set(0L);
         this.latch = latch;
         count = expectedCount;
+        batchesProcessed.set(0);
     }
 
     @Override
@@ -44,6 +47,11 @@ public final class LongArrayEventHandler implements EventHandler<long[]>
         for (int i = 0; i < event.length; i++)
         {
             value.set(value.get() + event[i]);
+        }
+
+        if (endOfBatch)
+        {
+            batchesProcessed.increment();
         }
 
         if (--count == 0)

--- a/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
@@ -32,7 +32,11 @@ public final class LongArrayEventHandler implements EventHandler<long[]>, BatchS
     {
         return value.get();
     }
-    public long getBatchesProcessed() { return batchesProcessed.get(); }
+
+    public long getBatchesProcessed()
+    {
+        return batchesProcessed.get();
+    }
 
     public void reset(final CountDownLatch latch, final long expectedCount)
     {

--- a/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
@@ -17,10 +17,11 @@ package com.lmax.disruptor.support;
 
 import java.util.concurrent.CountDownLatch;
 
+import com.lmax.disruptor.BatchStartAware;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.util.PaddedLong;
 
-public final class LongArrayEventHandler implements EventHandler<long[]>
+public final class LongArrayEventHandler implements EventHandler<long[]>, BatchStartAware
 {
     private final PaddedLong value = new PaddedLong();
     private final PaddedLong batchesProcessed = new PaddedLong();
@@ -49,14 +50,15 @@ public final class LongArrayEventHandler implements EventHandler<long[]>
             value.set(value.get() + event[i]);
         }
 
-        if (endOfBatch)
-        {
-            batchesProcessed.increment();
-        }
-
         if (--count == 0)
         {
             latch.countDown();
         }
+    }
+
+    @Override
+    public void onBatchStart(long batchSize)
+    {
+        batchesProcessed.increment();
     }
 }

--- a/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
@@ -32,7 +32,11 @@ public final class ValueAdditionEventHandler implements EventHandler<ValueEvent>
     {
         return value.get();
     }
-    public long getBatchesProcessed() { return batchesProcessed.get(); }
+
+    public long getBatchesProcessed()
+    {
+        return batchesProcessed.get();
+    }
 
     public void reset(final CountDownLatch latch, final long expectedCount)
     {

--- a/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
@@ -17,10 +17,11 @@ package com.lmax.disruptor.support;
 
 import java.util.concurrent.CountDownLatch;
 
+import com.lmax.disruptor.BatchStartAware;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.util.PaddedLong;
 
-public final class ValueAdditionEventHandler implements EventHandler<ValueEvent>
+public final class ValueAdditionEventHandler implements EventHandler<ValueEvent>, BatchStartAware
 {
     private final PaddedLong value = new PaddedLong();
     private final PaddedLong batchesProcessed = new PaddedLong();
@@ -46,14 +47,15 @@ public final class ValueAdditionEventHandler implements EventHandler<ValueEvent>
     {
         value.set(value.get() + event.getValue());
 
-        if (endOfBatch)
-        {
-            batchesProcessed.increment();
-        }
-
         if (count == sequence)
         {
             latch.countDown();
         }
+    }
+
+    @Override
+    public void onBatchStart(long batchSize)
+    {
+        batchesProcessed.increment();
     }
 }

--- a/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
@@ -23,6 +23,7 @@ import com.lmax.disruptor.util.PaddedLong;
 public final class ValueAdditionEventHandler implements EventHandler<ValueEvent>
 {
     private final PaddedLong value = new PaddedLong();
+    private final PaddedLong batchesProcessed = new PaddedLong();
     private long count;
     private CountDownLatch latch;
 
@@ -30,18 +31,25 @@ public final class ValueAdditionEventHandler implements EventHandler<ValueEvent>
     {
         return value.get();
     }
+    public long getBatchesProcessed() { return batchesProcessed.get(); }
 
     public void reset(final CountDownLatch latch, final long expectedCount)
     {
         value.set(0L);
         this.latch = latch;
         count = expectedCount;
+        batchesProcessed.set(0);
     }
 
     @Override
     public void onEvent(final ValueEvent event, final long sequence, final boolean endOfBatch) throws Exception
     {
         value.set(value.get() + event.getValue());
+
+        if (endOfBatch)
+        {
+            batchesProcessed.increment();
+        }
 
         if (count == sequence)
         {

--- a/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
@@ -24,6 +24,7 @@ public final class ValueMutationEventHandler implements EventHandler<ValueEvent>
 {
     private final Operation operation;
     private final PaddedLong value = new PaddedLong();
+    private final PaddedLong batchesProcessed = new PaddedLong();
     private long count;
     private CountDownLatch latch;
 
@@ -36,18 +37,25 @@ public final class ValueMutationEventHandler implements EventHandler<ValueEvent>
     {
         return value.get();
     }
+    public long getBatchesProcessed() { return batchesProcessed.get(); }
 
     public void reset(final CountDownLatch latch, final long expectedCount)
     {
         value.set(0L);
         this.latch = latch;
         count = expectedCount;
+        batchesProcessed.set(0);
     }
 
     @Override
     public void onEvent(final ValueEvent event, final long sequence, final boolean endOfBatch) throws Exception
     {
         value.set(operation.op(value.get(), event.getValue()));
+
+        if (endOfBatch)
+        {
+            batchesProcessed.increment();
+        }
 
         if (count == sequence)
         {

--- a/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
@@ -15,12 +15,13 @@
  */
 package com.lmax.disruptor.support;
 
+import com.lmax.disruptor.BatchStartAware;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.util.PaddedLong;
 
 import java.util.concurrent.CountDownLatch;
 
-public final class ValueMutationEventHandler implements EventHandler<ValueEvent>
+public final class ValueMutationEventHandler implements EventHandler<ValueEvent>, BatchStartAware
 {
     private final Operation operation;
     private final PaddedLong value = new PaddedLong();
@@ -52,14 +53,15 @@ public final class ValueMutationEventHandler implements EventHandler<ValueEvent>
     {
         value.set(operation.op(value.get(), event.getValue()));
 
-        if (endOfBatch)
-        {
-            batchesProcessed.increment();
-        }
-
         if (count == sequence)
         {
             latch.countDown();
         }
+    }
+
+    @Override
+    public void onBatchStart(long batchSize)
+    {
+        batchesProcessed.increment();
     }
 }

--- a/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
@@ -38,7 +38,11 @@ public final class ValueMutationEventHandler implements EventHandler<ValueEvent>
     {
         return value.get();
     }
-    public long getBatchesProcessed() { return batchesProcessed.get(); }
+
+    public long getBatchesProcessed()
+    {
+        return batchesProcessed.get();
+    }
 
     public void reset(final CountDownLatch latch, final long expectedCount)
     {

--- a/src/perftest/java/com/lmax/disruptor/translator/OneToOneTranslatorThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/translator/OneToOneTranslatorThroughputTest.java
@@ -15,10 +15,7 @@
  */
 package com.lmax.disruptor.translator;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.EventTranslatorOneArg;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.support.PerfTestUtil;
@@ -93,8 +90,9 @@ public final class OneToOneTranslatorThroughputTest extends AbstractPerfTestDisr
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         MutableLong value = this.value;
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -112,12 +110,13 @@ public final class OneToOneTranslatorThroughputTest extends AbstractPerfTestDisr
         }
 
         latch.await();
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
+        perfTestContext.setBatchData(handler.getBatchesProcessed(), ITERATIONS);
         waitForEventProcessorSequence(expectedCount);
 
         failIfNot(expectedResult, handler.getValue());
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     private static class Translator implements EventTranslatorOneArg<ValueEvent, MutableLong>

--- a/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeReleasingWorkerPoolThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeReleasingWorkerPoolThroughputTest.java
@@ -20,11 +20,7 @@ import static com.lmax.disruptor.support.PerfTestUtil.failIfNot;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.FatalExceptionHandler;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.WorkerPool;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.EventCountingAndReleasingWorkHandler;
 import com.lmax.disruptor.support.ValueEvent;
 import com.lmax.disruptor.util.DaemonThreadFactory;
@@ -85,8 +81,9 @@ public final class OneToThreeReleasingWorkerPoolThroughputTest
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
 
         resetCounters();
         RingBuffer<ValueEvent> ringBuffer = workerPool.start(executor);
@@ -104,11 +101,11 @@ public final class OneToThreeReleasingWorkerPoolThroughputTest
         // Workaround to ensure that the last worker(s) have completed after releasing their events
         Thread.sleep(1L);
 
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
 
         failIfNot(ITERATIONS, sumCounters());
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     private void resetCounters()

--- a/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeWorkerPoolThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/workhandler/OneToThreeWorkerPoolThroughputTest.java
@@ -22,11 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.FatalExceptionHandler;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.WorkerPool;
-import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.EventCountingQueueProcessor;
 import com.lmax.disruptor.support.EventCountingWorkHandler;
 import com.lmax.disruptor.support.ValueEvent;
@@ -99,8 +95,9 @@ public final class OneToThreeWorkerPoolThroughputTest
     }
 
     @Override
-    protected long runDisruptorPass() throws InterruptedException
+    protected PerfTestContext runDisruptorPass() throws InterruptedException
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
 
         resetCounters();
         RingBuffer<ValueEvent> ringBuffer = workerPool.start(executor);
@@ -114,11 +111,11 @@ public final class OneToThreeWorkerPoolThroughputTest
         }
 
         workerPool.drainAndHalt();
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
 
         failIfNot(ITERATIONS, sumCounters());
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     private void resetCounters()

--- a/src/perftest/java/com/lmax/disruptor/workhandler/TwoToTwoWorkProcessorThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/workhandler/TwoToTwoWorkProcessorThroughputTest.java
@@ -23,13 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.LockSupport;
 
-import com.lmax.disruptor.AbstractPerfTestDisruptor;
-import com.lmax.disruptor.BusySpinWaitStrategy;
-import com.lmax.disruptor.IgnoreExceptionHandler;
-import com.lmax.disruptor.RingBuffer;
-import com.lmax.disruptor.Sequence;
-import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.WorkProcessor;
+import com.lmax.disruptor.*;
 import com.lmax.disruptor.support.ValueAdditionWorkHandler;
 import com.lmax.disruptor.support.ValueEvent;
 import com.lmax.disruptor.support.ValuePublisher;
@@ -111,8 +105,9 @@ public final class TwoToTwoWorkProcessorThroughputTest extends AbstractPerfTestD
     }
 
     @Override
-    protected long runDisruptorPass() throws Exception
+    protected PerfTestContext runDisruptorPass() throws Exception
     {
+        PerfTestContext perfTestContext = new PerfTestContext();
         long expected = ringBuffer.getCursor() + (NUM_PUBLISHERS * ITERATIONS);
         Future<?>[] futures = new Future[NUM_PUBLISHERS];
         for (int i = 0; i < NUM_PUBLISHERS; i++)
@@ -138,7 +133,7 @@ public final class TwoToTwoWorkProcessorThroughputTest extends AbstractPerfTestD
             LockSupport.parkNanos(1L);
         }
 
-        long opsPerSecond = (ITERATIONS * 1000L) / (System.currentTimeMillis() - start);
+        perfTestContext.setDisruptorOps((ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
 
         Thread.sleep(1000);
 
@@ -147,7 +142,7 @@ public final class TwoToTwoWorkProcessorThroughputTest extends AbstractPerfTestD
             processor.halt();
         }
 
-        return opsPerSecond;
+        return perfTestContext;
     }
 
     public static void main(String[] args) throws Exception


### PR DESCRIPTION
We've recently added the batch percentage and average batch size to the disruptor-net performance tests.  We've found that it allows us to quickly see how the effects of batching impact the throughput figures.  I.e. the counter-intuitive effect that a slower consumer can lead to higher throughput as the rate of batching increases.