### PR TITLE
Fix batch size calculation in OneToOneSequencedBatchThroughputTest

### DIFF
--- a/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedBatchThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/sequenced/OneToOneSequencedBatchThroughputTest.java
@@ -111,7 +111,7 @@ public final class OneToOneSequencedBatchThroughputTest extends AbstractPerfTest
 
         latch.await();
         perfTestContext.setDisruptorOps((BATCH_SIZE * ITERATIONS * 1000L) / (System.currentTimeMillis() - start));
-        perfTestContext.setBatchData(handler.getBatchesProcessed(), ITERATIONS);
+        perfTestContext.setBatchData(handler.getBatchesProcessed(), ITERATIONS * BATCH_SIZE);
         waitForEventProcessorSequence(expectedCount);
         batchEventProcessor.halt();
 


### PR DESCRIPTION
Found an error in the calculation of the iteration count.