### PR TITLE
Disruptor DSL - don't register processors in Disruptor#after(EventProcessor...)

### DIFF
--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -313,11 +313,6 @@ public class Disruptor<T>
      */
     public EventHandlerGroup<T> after(final EventProcessor... processors)
     {
-        for (final EventProcessor processor : processors)
-        {
-            consumerRepository.add(processor);
-        }
-
         return new EventHandlerGroup<>(this, consumerRepository, Util.getSequencesFor(processors));
     }
 


### PR DESCRIPTION
This is bugfix for DSL method Disruptor#after(EventProcessor...)
According the javadoc, event processors must previously be set up with handleEventsWith or some other method. However event processors passed as arguments will be added into consumerRepository, which leads to duplicate attempts to start processing threads.
New unittest provided is checking that number of times new threads started is the same as number of event processors/handlers.