### PR TITLE
Add queue benchmark with batching

### DIFF
--- a/src/perftest/java/com/lmax/disruptor/queue/ThreeToOneQueueBatchThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/queue/ThreeToOneQueueBatchThroughputTest.java
@@ -15,18 +15,12 @@
  */
 package com.lmax.disruptor.queue;
 
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
 import com.lmax.disruptor.AbstractPerfTestQueue;
-import com.lmax.disruptor.support.ValueAdditionQueueProcessor;
+import com.lmax.disruptor.support.ValueAdditionQueueBatchProcessor;
 import com.lmax.disruptor.support.ValueQueuePublisher;
 import com.lmax.disruptor.util.DaemonThreadFactory;
+
+import java.util.concurrent.*;
 
 /**
  * <pre>
@@ -69,7 +63,7 @@ import com.lmax.disruptor.util.DaemonThreadFactory;
  *
  * </pre>
  */
-public final class ThreeToOneQueueThroughputTest extends AbstractPerfTestQueue
+public final class ThreeToOneQueueBatchThroughputTest extends AbstractPerfTestQueue
 {
     private static final int NUM_PUBLISHERS = 3;
     private static final int BUFFER_SIZE = 1024 * 64;
@@ -79,9 +73,9 @@ public final class ThreeToOneQueueThroughputTest extends AbstractPerfTestQueue
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    private final BlockingQueue<Long> blockingQueue = new ArrayBlockingQueue<>(BUFFER_SIZE);
-    private final ValueAdditionQueueProcessor queueProcessor =
-        new ValueAdditionQueueProcessor(blockingQueue, ((ITERATIONS / NUM_PUBLISHERS) * NUM_PUBLISHERS) - 1L);
+    private final BlockingQueue<Long> blockingQueue = new ArrayBlockingQueue<Long>(BUFFER_SIZE);
+    private final ValueAdditionQueueBatchProcessor queueProcessor =
+        new ValueAdditionQueueBatchProcessor(blockingQueue, ((ITERATIONS / NUM_PUBLISHERS) * NUM_PUBLISHERS) - 1L);
     private final ValueQueuePublisher[] valueQueuePublishers = new ValueQueuePublisher[NUM_PUBLISHERS];
 
     {
@@ -132,6 +126,6 @@ public final class ThreeToOneQueueThroughputTest extends AbstractPerfTestQueue
 
     public static void main(String[] args) throws Exception
     {
-        new ThreeToOneQueueThroughputTest().testImplementations();
+        new ThreeToOneQueueBatchThroughputTest().testImplementations();
     }
 }

--- a/src/perftest/java/com/lmax/disruptor/support/ValueAdditionQueueBatchProcessor.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueAdditionQueueBatchProcessor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor.support;
+
+import java.util.ArrayList;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+
+public final class ValueAdditionQueueBatchProcessor implements Runnable
+{
+    private volatile boolean running;
+    private long value;
+    private long sequence;
+    private CountDownLatch latch;
+
+    private final BlockingQueue<Long> blockingQueue;
+    private final ArrayList<Long> buffer = new ArrayList<>();
+    private final long count;
+
+    public ValueAdditionQueueBatchProcessor(final BlockingQueue<Long> blockingQueue, final long count)
+    {
+        this.blockingQueue = blockingQueue;
+        this.count = count;
+    }
+
+    public long getValue()
+    {
+        return value;
+    }
+
+    public void reset(final CountDownLatch latch)
+    {
+        value = 0L;
+        sequence = 0L;
+        this.latch = latch;
+    }
+
+    public void halt()
+    {
+        running = false;
+    }
+
+    @Override
+    public void run()
+    {
+        running = true;
+        while (true)
+        {
+            try
+            {
+                blockingQueue.drainTo(buffer);
+                if (buffer.isEmpty()) {
+                    long value = blockingQueue.take().longValue();
+                    this.value += value;
+                    ++sequence;
+                } else {
+                    for (Long v : buffer) {
+                        this.value += v;
+                    }
+                    sequence += buffer.size();
+                    buffer.clear();
+                }
+
+                if (sequence >= count) {
+                    latch.countDown();
+                }
+            }
+            catch (InterruptedException ex)
+            {
+                if (!running)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Replace LinkedBlockingQueue with ArrayBlockingQueue as it's faster.

Benchmarks from my desktop (Linux, Intel® Core™ i7-6850K CPU @ 3.60GHz × 12)

## ThreeToOneQueueThroughputTest (no batching)
### ArrayBlockingQueue
```
Run 0, BlockingQueue=5,279,831 ops/sec
Run 1, BlockingQueue=4,595,588 ops/sec
Run 2, BlockingQueue=5,028,916 ops/sec
Run 3, BlockingQueue=5,606,952 ops/sec
Run 4, BlockingQueue=5,268,703 ops/sec
Run 5, BlockingQueue=5,054,334 ops/sec
Run 6, BlockingQueue=4,800,768 ops/sec
```
### LinkedBlockingQueue
```
Run 0, BlockingQueue=3,757,279 ops/sec
Run 1, BlockingQueue=3,611,412 ops/sec
Run 2, BlockingQueue=3,725,088 ops/sec
Run 3, BlockingQueue=3,599,064 ops/sec
Run 4, BlockingQueue=3,591,309 ops/sec
Run 5, BlockingQueue=3,602,954 ops/sec
Run 6, BlockingQueue=3,692,762 ops/sec
```
## ThreeToOneQueueBatchThroughputTest (with batching)
### ArrayBlockingQueue
```
Run 0, BlockingQueue=11,049,723 ops/sec
Run 1, BlockingQueue=11,514,104 ops/sec
Run 2, BlockingQueue=11,627,906 ops/sec
Run 3, BlockingQueue=11,940,298 ops/sec
Run 4, BlockingQueue=12,113,870 ops/sec
Run 5, BlockingQueue=11,648,223 ops/sec
Run 6, BlockingQueue=11,883,541 ops/sec
```
### LinkedBlockingQueue
```
Run 0, BlockingQueue=6,029,544 ops/sec
Run 1, BlockingQueue=5,379,236 ops/sec
Run 2, BlockingQueue=5,390,835 ops/sec
Run 3, BlockingQueue=5,190,760 ops/sec
Run 4, BlockingQueue=5,250,721 ops/sec
Run 5, BlockingQueue=5,220,569 ops/sec
Run 6, BlockingQueue=5,341,880 ops/sec
```
## Disruptor timings for the reference
### ThreeToOneSequencedThroughputTest
```
Run 0, Disruptor=7,291,286 ops/sec BatchPercent=36.87% AverageBatchSize=1
Run 1, Disruptor=7,150,518 ops/sec BatchPercent=33.83% AverageBatchSize=1
Run 2, Disruptor=7,135,212 ops/sec BatchPercent=33.59% AverageBatchSize=1
Run 3, Disruptor=7,072,135 ops/sec BatchPercent=34.29% AverageBatchSize=1
Run 4, Disruptor=7,027,406 ops/sec BatchPercent=33.67% AverageBatchSize=1
Run 5, Disruptor=7,029,876 ops/sec BatchPercent=33.80% AverageBatchSize=1
Run 6, Disruptor=7,029,876 ops/sec BatchPercent=33.60% AverageBatchSize=1
```
### ThreeToOneSequencedBatchThroughputTest
```
Run 0, Disruptor=134,589,502 ops/sec BatchPercent=98.34% AverageBatchSize=60
Run 1, Disruptor=99,108,027 ops/sec BatchPercent=98.61% AverageBatchSize=72
Run 2, Disruptor=95,877,277 ops/sec BatchPercent=97.68% AverageBatchSize=43
Run 3, Disruptor=97,560,975 ops/sec BatchPercent=97.69% AverageBatchSize=43
Run 4, Disruptor=97,656,250 ops/sec BatchPercent=97.75% AverageBatchSize=44
Run 5, Disruptor=98,522,167 ops/sec BatchPercent=97.81% AverageBatchSize=45
Run 6, Disruptor=97,656,250 ops/sec BatchPercent=97.70% AverageBatchSize=43
```