### PR TITLE
Introduce new data structure for faster shutdown()

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jul 07 12:07:34 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,3 @@
-#Sun Jul 07 12:07:34 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jul 07 12:07:34 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-all.zip

--- a/src/main/java/com/lmax/disruptor/dsl/ConsumerRepository.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ConsumerRepository.java
@@ -16,6 +16,7 @@
 package com.lmax.disruptor.dsl;
 
 import com.lmax.disruptor.*;
+import com.lmax.disruptor.util.LinkedArrayList;
 
 import java.util.*;
 
@@ -60,19 +61,19 @@ class ConsumerRepository<T> implements Iterable<ConsumerInfo>
         }
     }
 
-    public Sequence[] getLastSequenceInChain(boolean includeStopped)
+    public LinkedArrayList<Sequence> getLastSequenceInChain(boolean includeStopped)
     {
-        List<Sequence> lastSequence = new ArrayList<>();
+        LinkedArrayList<Sequence> lastSequence = new LinkedArrayList<>();
         for (ConsumerInfo consumerInfo : consumerInfos)
         {
             if ((includeStopped || consumerInfo.isRunning()) && consumerInfo.isEndOfChain())
             {
                 final Sequence[] sequences = consumerInfo.getSequences();
-                Collections.addAll(lastSequence, sequences);
+                lastSequence.addArray(sequences);
             }
         }
 
-        return lastSequence.toArray(new Sequence[lastSequence.size()]);
+        return lastSequence;
     }
 
     public EventProcessor getEventProcessorFor(final EventHandler<T> handler)

--- a/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
+++ b/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
@@ -1,0 +1,418 @@
+package com.lmax.disruptor.util;
+
+import java.util.*;
+
+
+public class LinkedArrayList<T> implements List<T>
+{
+  LinkedArrayList<T> prev = null;
+  LinkedArrayList<T> next = null;
+
+  T[] myArray = null;
+
+
+  public LinkedArrayList()
+  {
+    this(null);
+  }
+
+  public LinkedArrayList(T[] arr)
+  {
+    myArray = arr;
+  }
+
+
+  @Override
+  public int size()
+  {
+    int size = myArray.length;
+    if (next != null ) size += next.size();
+    return size;
+  }
+
+  @Override
+  public boolean isEmpty()
+  {
+    return myArray.length == 0 && (next == null || next.isEmpty());
+  }
+
+  @Override
+  public boolean contains(Object o)
+  {
+    return indexOf(o) > 0;
+  }
+
+  @Override
+  public Iterator iterator()
+  {
+    LinkedArrayList linkedArrayList = this;
+    return new Iterator() {
+
+      LinkedArrayList current = linkedArrayList;
+      int currentIdx = 0;
+
+      @Override
+      public boolean hasNext()
+      {
+        return current.myArray.length > currentIdx || ! next.isEmpty();
+      }
+
+      @Override
+      public Object next()
+      {
+        while (true)
+        {
+          if (current.myArray != null && current.myArray.length > currentIdx)
+          {
+            Object retVal = current.myArray[currentIdx++];
+
+            if (currentIdx > current.myArray.length)
+            {
+              currentIdx -= current.myArray.length;
+              current = current.next;
+            }
+
+            return retVal;
+          }
+          else if (current.next == null)
+          {
+            throw new NoSuchElementException();
+          }
+          else
+          {
+            current = current.next;
+          }
+        }
+      }
+    };
+  }
+
+  @Override
+  public Object[] toArray()
+  {
+    throw new RuntimeException("I'm not sure you get the point of this class");
+  }
+
+  @Override
+  public boolean add(Object o)
+  {
+    return addArray(new Object[]{o});
+  }
+
+  @Override
+  public boolean remove(Object o)
+  {
+    throw new RuntimeException("Try exhibiting a little Mechanical Sympathy");
+  }
+
+  public boolean addArray(Object[] arr)
+  {
+    if (next == null)
+    {
+      // TODO this would be god to fix at some point
+      //noinspection unchecked
+      next = new LinkedArrayList<>((T[]) arr);
+      return true;
+    }
+    else
+    {
+      return next.addArray(arr);
+    }
+  }
+
+  @Override
+  public boolean addAll(Collection c)
+  {
+    if (c.isEmpty())
+    {
+      return false;
+    }
+
+    if (c.getClass() == LinkedArrayList.class)
+    {
+      if (next == null)
+      {
+        // It is checked, that's what the if statement is all about...
+        //noinspection unchecked
+        next = (LinkedArrayList<T>) c;
+        return true;
+      }
+
+      else return next.addAll(c);
+    }
+
+    return addArray(c.toArray());
+  }
+
+  @Override
+  public boolean addAll(int index, Collection c)
+  {
+    throw new RuntimeException
+    (
+    "Implementing this method would be an insult to you and me both, why do you want me to insult you?"
+    );
+  }
+
+  @Override
+  public void clear()
+  {
+    myArray = null;
+    next = null;
+  }
+
+  private T internalGet(int originalIndex, int subIndex)
+  {
+    if (myArray.length > subIndex)
+    {
+      return myArray[subIndex];
+    }
+
+    if (next != null)
+    {
+      return next.internalGet(originalIndex, subIndex - myArray.length);
+    }
+
+    throw new IndexOutOfBoundsException
+    (
+    "You're just too big for me, originalIndex: "
+    + originalIndex
+    + ", subIndex: "
+    + subIndex
+    );
+  }
+
+  @Override
+  public T get(int index)
+  {
+    return internalGet(index, index);
+  }
+
+  private T internalSet(T o, int originalIndex, int subIndex)
+  {
+    if (myArray.length > subIndex)
+    {
+      // TODO should fix this at some point
+      //noinspection unchecked
+      myArray[subIndex] = (T) o;
+    }
+
+    if (next != null)
+    {
+      return next.internalSet(o, originalIndex, subIndex - myArray.length);
+    }
+
+    throw new IndexOutOfBoundsException
+    (
+    "You're just too big for me, originalIndex: "
+    + originalIndex
+    + ", subIndex: "
+    + subIndex
+    );
+  }
+
+  @Override
+  public T set(int index, T element)
+  {
+    return internalSet(element, index, index);
+  }
+
+  @Override
+  public void add(int index, Object element)
+  {
+    throw new RuntimeException("Seriously? Why on earth would you do this to a perfectly innocent computer?");
+  }
+
+  @Override
+  public T remove(int index)
+  {
+    throw new RuntimeException("Seriously? Why on earth would you do this to a perfectly innocent computer?");
+  }
+
+  @Override
+  public int indexOf(Object o)
+  {
+    if (myArray != null && myArray.length != 0)
+    {
+      //check against first element for class match
+      if (myArray[0].getClass() != o.getClass())
+      {
+        return -2; //like probs not, right?
+      }
+
+      for (int i = 0; i < myArray.length; i++)
+      {
+        if (myArray[i] == o)
+        {
+          return i;
+        }
+      }
+    }
+
+    if (next == null)
+    {
+      return -1;
+    }
+
+    return next.indexOf(o);
+  }
+
+  @Override
+  public int lastIndexOf(Object o)
+  {
+    int restOfListResult;
+    if (next != null)
+    {
+      restOfListResult = next.lastIndexOf(o);
+
+      if (restOfListResult > 0)
+      {
+        return restOfListResult + myArray.length;
+      }
+    }
+
+    for (int i = myArray.length; i > 0; i--)
+    {
+      if (myArray[i - 1] == o)
+      {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  @Override
+  public ListIterator listIterator()
+  {
+    return listIterator(0);
+  }
+
+  @Override
+  public ListIterator listIterator(int index)
+  {
+    LinkedArrayList linkedArrayList = this;
+    return new ListIterator() {
+
+      LinkedArrayList current = linkedArrayList;
+      int currentIdx = 0;
+
+      @Override
+      public boolean hasNext()
+      {
+        return current.myArray.length > currentIdx || ! next.isEmpty();
+      }
+
+      @Override
+      public Object next()
+      {
+        while (true)
+        {
+          if (current.myArray != null && current.myArray.length > currentIdx)
+          {
+            Object retVal = current.myArray[currentIdx++];
+
+            if (currentIdx > current.myArray.length)
+            {
+              currentIdx -= current.myArray.length;
+              current = current.next;
+            }
+
+            return retVal;
+          }
+          else if (current.next == null)
+          {
+            throw new NoSuchElementException();
+          }
+          else
+          {
+            current = current.next;
+          }
+        }
+      }
+
+      @Override
+      public boolean hasPrevious()
+      {
+        throw new UnsupportedOperationException("Not implemented");
+      }
+
+      @Override
+      public Object previous()
+      {
+        throw new UnsupportedOperationException("Not implemented");
+      }
+
+      @Override
+      public int nextIndex()
+      {
+        return currentIdx;
+      }
+
+      @Override
+      public int previousIndex()
+      {
+        return currentIdx - 1;
+      }
+
+      @Override
+      public void remove()
+      {
+        throw new UnsupportedOperationException("Not implemented");
+
+      }
+
+      @Override
+      public void set(Object o)
+      {
+        throw new UnsupportedOperationException("Not implemented");
+      }
+
+      @Override
+      public void add(Object o)
+      {
+        throw new UnsupportedOperationException("Not implemented");
+      }
+    };
+  }
+
+  @Override
+  public List subList(int fromIndex, int toIndex)
+  {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean retainAll(Collection c)
+  {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean removeAll(Collection c)
+  {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean containsAll(Collection c)
+  {
+    // would normally construct a HashSet along the ay here, but the whole
+    // point of this Collection is to avoid allocating intermediate
+    // arrays
+    for (Object o : c)
+    {
+      if (!contains(o))
+      {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public Object[] toArray(Object[] a)
+  {
+    throw new RuntimeException("You really don't get what I'm trying to do here");
+  }
+}

--- a/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
+++ b/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
@@ -53,7 +53,16 @@ public class LinkedArrayList<T> implements List<T>
       @Override
       public boolean hasNext()
       {
-        return (current.myArray != null && current.myArray.length > currentIdx) || ! current.next.isEmpty();
+        return
+        (
+          current.myArray != null && current.myArray.length > currentIdx
+        )
+        ||
+        (
+          current.next != null
+          &&
+          ! current.next.isEmpty()
+        );
       }
 
       @Override
@@ -108,8 +117,6 @@ public class LinkedArrayList<T> implements List<T>
   {
     if (next == null)
     {
-      // TODO this would be god to fix at some point
-      //noinspection unchecked
       next = new LinkedArrayList<>((T[]) arr);
       return true;
     }
@@ -299,7 +306,16 @@ public class LinkedArrayList<T> implements List<T>
       @Override
       public boolean hasNext()
       {
-        return (current.myArray != null && current.myArray.length > currentIdx) || ! current.next.isEmpty();
+        return
+        (
+          current.myArray != null && current.myArray.length > currentIdx
+        )
+        ||
+        (
+          current.next != null
+          &&
+          !current.next.isEmpty()
+        );
       }
 
       @Override

--- a/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
+++ b/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
@@ -32,7 +32,7 @@ public class LinkedArrayList<T> implements List<T>
   @Override
   public boolean isEmpty()
   {
-    return (myArray != null && myArray.length == 0) && (next == null || next.isEmpty());
+    return (myArray == null || myArray.length == 0) && (next == null || next.isEmpty());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class LinkedArrayList<T> implements List<T>
         (
           current.next != null
           &&
-          ! current.next.isEmpty()
+          !current.next.isEmpty()
         );
       }
 
@@ -72,22 +72,19 @@ public class LinkedArrayList<T> implements List<T>
         {
           if (current.myArray != null && current.myArray.length > currentIdx)
           {
-            T retVal = current.myArray[currentIdx++];
-
-            if (currentIdx > current.myArray.length)
-            {
-              currentIdx -= current.myArray.length;
-              current = current.next;
-            }
-
-            return retVal;
+            return current.myArray[currentIdx++];
           }
           else if (current.next == null)
           {
+            if (hasNext())
+            {
+              throw new NoSuchElementException("I guess we lied to someone, sorry about that");
+            }
             throw new NoSuchElementException();
           }
           else
           {
+            currentIdx -= current.myArray == null ? 0 : current.myArray.length;
             current = current.next;
           }
         }
@@ -115,14 +112,18 @@ public class LinkedArrayList<T> implements List<T>
 
   public boolean addArray(Object[] arr)
   {
-    if (next == null)
+    LinkedArrayList iter = this;
+    while (true)
     {
-      next = new LinkedArrayList<>((T[]) arr);
-      return true;
-    }
-    else
-    {
-      return next.addArray(arr);
+      if (iter.next == null)
+      {
+        iter.next = new LinkedArrayList<>((T[]) arr);
+        return true;
+      }
+      else
+      {
+        iter = iter.next;
+      }
     }
   }
 
@@ -155,7 +156,7 @@ public class LinkedArrayList<T> implements List<T>
   {
     throw new RuntimeException
     (
-    "Implementing this method would be an insult to you and me both, why do you want me to insult you?"
+      "Implementing this method would be an insult to you and me both, why do you want me to insult you?"
     );
   }
 
@@ -180,10 +181,10 @@ public class LinkedArrayList<T> implements List<T>
 
     throw new IndexOutOfBoundsException
     (
-    "You're just too big for me, originalIndex: "
-    + originalIndex
-    + ", subIndex: "
-    + subIndex
+      "You're just too big for me, originalIndex: "
+      + originalIndex
+      + ", subIndex: "
+      + subIndex
     );
   }
 
@@ -207,10 +208,10 @@ public class LinkedArrayList<T> implements List<T>
 
     throw new IndexOutOfBoundsException
     (
-    "You're just too big for me, originalIndex: "
-    + originalIndex
-    + ", subIndex: "
-    + subIndex
+      "You're just too big for me, originalIndex: "
+      + originalIndex
+      + ", subIndex: "
+      + subIndex
     );
   }
 
@@ -325,15 +326,7 @@ public class LinkedArrayList<T> implements List<T>
         {
           if (current.myArray != null && current.myArray.length > currentIdx)
           {
-            T retVal = current.myArray[currentIdx++];
-
-            if (currentIdx > current.myArray.length)
-            {
-              currentIdx -= current.myArray.length;
-              current = current.next;
-            }
-
-            return retVal;
+            return current.myArray[currentIdx++];
           }
           else if (current.next == null)
           {
@@ -341,6 +334,7 @@ public class LinkedArrayList<T> implements List<T>
           }
           else
           {
+            currentIdx -= current.myArray == null ? 0 : current.myArray.length;
             current = current.next;
           }
         }

--- a/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
+++ b/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
@@ -2,7 +2,6 @@ package com.lmax.disruptor.util;
 
 import java.util.*;
 
-
 public class LinkedArrayList<T> implements List<T>
 {
   LinkedArrayList<T> prev = null;
@@ -25,7 +24,7 @@ public class LinkedArrayList<T> implements List<T>
   @Override
   public int size()
   {
-    int size = myArray.length;
+    int size = myArray == null ? 0 : myArray.length;
     if (next != null ) size += next.size();
     return size;
   }
@@ -33,7 +32,7 @@ public class LinkedArrayList<T> implements List<T>
   @Override
   public boolean isEmpty()
   {
-    return myArray.length == 0 && (next == null || next.isEmpty());
+    return (myArray != null && myArray.length == 0) && (next == null || next.isEmpty());
   }
 
   @Override
@@ -48,14 +47,13 @@ public class LinkedArrayList<T> implements List<T>
     final LinkedArrayList localThis = this;
     return new Iterator() {
 
-
       LinkedArrayList current = localThis;
       int currentIdx = 0;
 
       @Override
       public boolean hasNext()
       {
-        return current.myArray.length > currentIdx || ! next.isEmpty();
+        return (current.myArray != null && current.myArray.length > currentIdx) || ! next.isEmpty();
       }
 
       @Override
@@ -163,7 +161,7 @@ public class LinkedArrayList<T> implements List<T>
 
   private T internalGet(int originalIndex, int subIndex)
   {
-    if (myArray.length > subIndex)
+    if (myArray != null && myArray.length > subIndex)
     {
       return myArray[subIndex];
     }
@@ -190,7 +188,7 @@ public class LinkedArrayList<T> implements List<T>
 
   private T internalSet(T o, int originalIndex, int subIndex)
   {
-    if (myArray.length > subIndex)
+    if (myArray != null && myArray.length > subIndex)
     {
       // TODO should fix this at some point
       //noinspection unchecked
@@ -218,7 +216,7 @@ public class LinkedArrayList<T> implements List<T>
   }
 
   @Override
-  public void add(int index, Object element)
+  public void add(int index, T element)
   {
     throw new RuntimeException("Seriously? Why on earth would you do this to a perfectly innocent computer?");
   }
@@ -271,11 +269,14 @@ public class LinkedArrayList<T> implements List<T>
       }
     }
 
-    for (int i = myArray.length; i > 0; i--)
+    if (myArray != null)
     {
-      if (myArray[i - 1] == o)
+      for (int i = myArray.length; i > 0; i--)
       {
-        return i;
+        if (myArray[i - 1] == o)
+        {
+          return i;
+        }
       }
     }
 
@@ -292,8 +293,6 @@ public class LinkedArrayList<T> implements List<T>
   public ListIterator listIterator(int index)
   {
     final LinkedArrayList localThis = this;
-
-
     return new ListIterator() {
 
       LinkedArrayList current = localThis;
@@ -361,7 +360,6 @@ public class LinkedArrayList<T> implements List<T>
       public void remove()
       {
         throw new UnsupportedOperationException("Not implemented");
-
       }
 
       @Override

--- a/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
+++ b/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
@@ -302,7 +302,7 @@ public class LinkedArrayList<T> implements List<T>
       @Override
       public boolean hasNext()
       {
-        return current.myArray.length > currentIdx || ! next.isEmpty();
+        return (current.myArray != null && current.myArray.length > currentIdx) || ! current.next.isEmpty();
       }
 
       @Override

--- a/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
+++ b/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
@@ -42,28 +42,28 @@ public class LinkedArrayList<T> implements List<T>
   }
 
   @Override
-  public Iterator iterator()
+  public Iterator<T> iterator()
   {
-    final LinkedArrayList localThis = this;
-    return new Iterator() {
+    final LinkedArrayList<T> localThis = this;
+    return new Iterator<T>() {
 
-      LinkedArrayList current = localThis;
+      LinkedArrayList<T> current = localThis;
       int currentIdx = 0;
 
       @Override
       public boolean hasNext()
       {
-        return (current.myArray != null && current.myArray.length > currentIdx) || ! next.isEmpty();
+        return (current.myArray != null && current.myArray.length > currentIdx) || ! current.next.isEmpty();
       }
 
       @Override
-      public Object next()
+      public T next()
       {
         while (true)
         {
           if (current.myArray != null && current.myArray.length > currentIdx)
           {
-            Object retVal = current.myArray[currentIdx++];
+            T retVal = current.myArray[currentIdx++];
 
             if (currentIdx > current.myArray.length)
             {
@@ -168,7 +168,7 @@ public class LinkedArrayList<T> implements List<T>
 
     if (next != null)
     {
-      return next.internalGet(originalIndex, subIndex - myArray.length);
+      return next.internalGet(originalIndex, subIndex - (myArray == null ? 0 : myArray.length));
     }
 
     throw new IndexOutOfBoundsException
@@ -190,14 +190,12 @@ public class LinkedArrayList<T> implements List<T>
   {
     if (myArray != null && myArray.length > subIndex)
     {
-      // TODO should fix this at some point
-      //noinspection unchecked
-      myArray[subIndex] = (T) o;
+      myArray[subIndex] = o;
     }
 
     if (next != null)
     {
-      return next.internalSet(o, originalIndex, subIndex - myArray.length);
+      return next.internalSet(o, originalIndex, subIndex - (myArray == null ? 0 :myArray.length));
     }
 
     throw new IndexOutOfBoundsException
@@ -284,18 +282,18 @@ public class LinkedArrayList<T> implements List<T>
   }
 
   @Override
-  public ListIterator listIterator()
+  public ListIterator<T> listIterator()
   {
     return listIterator(0);
   }
 
   @Override
-  public ListIterator listIterator(int index)
+  public ListIterator<T> listIterator(int index)
   {
-    final LinkedArrayList localThis = this;
-    return new ListIterator() {
+    final LinkedArrayList<T> localThis = this;
+    return new ListIterator<T>() {
 
-      LinkedArrayList current = localThis;
+      LinkedArrayList<T> current = localThis;
       int currentIdx = 0;
 
       @Override
@@ -305,13 +303,13 @@ public class LinkedArrayList<T> implements List<T>
       }
 
       @Override
-      public Object next()
+      public T next()
       {
         while (true)
         {
           if (current.myArray != null && current.myArray.length > currentIdx)
           {
-            Object retVal = current.myArray[currentIdx++];
+            T retVal = current.myArray[currentIdx++];
 
             if (currentIdx > current.myArray.length)
             {
@@ -339,7 +337,7 @@ public class LinkedArrayList<T> implements List<T>
       }
 
       @Override
-      public Object previous()
+      public T previous()
       {
         throw new UnsupportedOperationException("Not implemented");
       }
@@ -377,7 +375,7 @@ public class LinkedArrayList<T> implements List<T>
   }
 
   @Override
-  public List subList(int fromIndex, int toIndex)
+  public List<T> subList(int fromIndex, int toIndex)
   {
     throw new UnsupportedOperationException("Not implemented");
   }

--- a/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
+++ b/src/main/java/com/lmax/disruptor/util/LinkedArrayList.java
@@ -45,10 +45,11 @@ public class LinkedArrayList<T> implements List<T>
   @Override
   public Iterator iterator()
   {
-    LinkedArrayList linkedArrayList = this;
+    final LinkedArrayList localThis = this;
     return new Iterator() {
 
-      LinkedArrayList current = linkedArrayList;
+
+      LinkedArrayList current = localThis;
       int currentIdx = 0;
 
       @Override
@@ -290,10 +291,12 @@ public class LinkedArrayList<T> implements List<T>
   @Override
   public ListIterator listIterator(int index)
   {
-    LinkedArrayList linkedArrayList = this;
+    final LinkedArrayList localThis = this;
+
+
     return new ListIterator() {
 
-      LinkedArrayList current = linkedArrayList;
+      LinkedArrayList current = localThis;
       int currentIdx = 0;
 
       @Override

--- a/src/test/java/com/lmax/disruptor/dsl/ConsumerRepositoryTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/ConsumerRepositoryTest.java
@@ -22,6 +22,7 @@ import com.lmax.disruptor.dsl.stubs.SleepingEventHandler;
 import com.lmax.disruptor.support.DummyEventProcessor;
 import com.lmax.disruptor.support.DummySequenceBarrier;
 import com.lmax.disruptor.support.TestEvent;
+import com.lmax.disruptor.util.LinkedArrayList;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -78,9 +79,9 @@ public class ConsumerRepositoryTest
         consumerRepository.unMarkEventProcessorsAsEndOfChain(eventProcessor2.getSequence());
 
 
-        final Sequence[] lastEventProcessorsInChain = consumerRepository.getLastSequenceInChain(true);
-        assertThat(lastEventProcessorsInChain.length, equalTo(1));
-        assertThat(lastEventProcessorsInChain[0], sameInstance(eventProcessor1.getSequence()));
+        final LinkedArrayList<Sequence> lastEventProcessorsInChain = consumerRepository.getLastSequenceInChain(true);
+        assertThat(lastEventProcessorsInChain.size(), equalTo(1));
+        assertThat(lastEventProcessorsInChain.get(0), sameInstance(eventProcessor1.getSequence()));
     }
 
     @Test

--- a/src/test/java/com/lmax/disruptor/util/LinkedArrayListTest.java
+++ b/src/test/java/com/lmax/disruptor/util/LinkedArrayListTest.java
@@ -1,0 +1,10 @@
+package com.lmax.disruptor.util;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class LinkedArrayListTest
+{
+}

--- a/src/test/java/com/lmax/disruptor/util/LinkedArrayListTest.java
+++ b/src/test/java/com/lmax/disruptor/util/LinkedArrayListTest.java
@@ -4,7 +4,64 @@ package com.lmax.disruptor.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Iterator;
+import java.util.Random;
+
 
 public class LinkedArrayListTest
 {
+  @Test
+  public void iteratorTest()
+  {
+    Integer[][] arrays = new Integer[6][];
+
+    for (int i = 0; i < 6; i++)
+    {
+      arrays[i] = new Integer[6];
+
+      for (int j = 0; j < arrays[i].length; j++)
+      {
+        arrays[i][j] = 2;
+      }
+    }
+
+    LinkedArrayList<Integer> lal = new LinkedArrayList<>();
+    Random random = new Random();
+
+    for (int i = 0; i < 6; i++)
+    {
+      int before = random.nextInt(13);
+      for (int j = 0; j < before; j++)
+      {
+        lal.addArray(new Integer[]{});
+      }
+
+      lal.addArray(arrays[i]);
+
+      int after = random.nextInt(13);
+      for (int j = 0; j < after; j++)
+      {
+        lal.addArray(new Integer[]{});
+      }
+    }
+
+    Iterator<Integer> it = lal.iterator();
+
+    for (int i = 0; i < 36; i++)
+    {
+      assert it.next() == 2;
+    }
+
+    assert !it.hasNext();
+
+    int count = 0;
+    for (Integer i : lal)
+    {
+      count++;
+      assert  i == 2;
+    }
+
+    assert count == 36;
+  }
+
 }


### PR DESCRIPTION
Repeated addAll operations on Sequence[]s in shutdown() were causing excessive allocations, using a linked list to join the arrays yielded instead of allocating and copying seems to significantly speed things up. Happy to post YourKit results if that would be helpful.