### PR TITLE
Delegate hasBacklog to ConsumerRepository

### DIFF
--- a/src/main/java/com/lmax/disruptor/dsl/ConsumerRepository.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ConsumerRepository.java
@@ -60,6 +60,30 @@ class ConsumerRepository<T> implements Iterable<ConsumerInfo>
         }
     }
 
+    public boolean hasBacklog(long cursor, boolean includeStopped)
+    {
+        for (ConsumerInfo consumerInfo : consumerInfos)
+        {
+            if ((includeStopped || consumerInfo.isRunning()) && consumerInfo.isEndOfChain())
+            {
+                final Sequence[] sequences = consumerInfo.getSequences();
+                for (Sequence sequence : sequences)
+                {
+                    if (cursor > sequence.get())
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @deprecated this function should no longer be used to determine the existence
+     * of a backlog, instead use hasBacklog
+     */
     public Sequence[] getLastSequenceInChain(boolean includeStopped)
     {
         List<Sequence> lastSequence = new ArrayList<>();

--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -530,14 +530,8 @@ public class Disruptor<T>
     private boolean hasBacklog()
     {
         final long cursor = ringBuffer.getCursor();
-        for (final Sequence consumer : consumerRepository.getLastSequenceInChain(false))
-        {
-            if (cursor > consumer.get())
-            {
-                return true;
-            }
-        }
-        return false;
+
+        return consumerRepository.hasBacklog(cursor, false);
     }
 
     EventHandlerGroup<T> createEventProcessors(


### PR DESCRIPTION
Stop doing unnecessary allocations in hasBacklog by delegating to ConsumerRepository rather than having ConsumerRepository pass back a Collection made of concatenated arrays. 