### PR TITLE
Add Automatic-Module-Name to MANIFEST.MF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ ext {
     teamName = 'LMAX Disruptor Development Team'
     siteUrl = 'http://lmax-exchange.github.com/disruptor'
     sourceUrl = 'git@github.com:LMAX-Exchange/disruptor.git'
+    moduleName = 'com.lmax.disruptor'
 
     javaCompilerExecutable = System.env['JAVA_HOME'] ? System.env['JAVA_HOME'] + '/bin/javac' : 'javac'
 
@@ -99,7 +100,8 @@ jar {
                         'Bundle-Name': fullName,
                         'Bundle-Vendor': teamName,
                         'Bundle-Description': fullDescription,
-                        'Bundle-DocURL': siteUrl)
+                        'Bundle-DocURL': siteUrl,
+                        'Automatic-Module-Name': moduleName)
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
This is the first step in the process of modularizing the Disruptor JAR #234.
Adding Automatic-Module-Name in the manifest file makes the library usable as a Java automatic module without moving the library itself to Java 9 (or later) or creating a module-info.java.
This allows the Disruptor when loaded as an automatic module to get its name from the Automatic-Module-Name entry in MANIFEST.MF instead of being inferred from the filename. This second option is dangerous as filenames are far from being unique and stable.
This post explains the point of having an Automatic-Module-Name defined: http://branchandbound.net/blog/java/2017/12/automatic-module-name/