### PR TITLE
allow builds with single thread

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ compileJava {
 }
 
 tasks.withType(Test) {
-    maxParallelForks = Runtime.runtime.availableProcessors() / 2
+    maxParallelForks = Math.max(Math.floor(Runtime.runtime.availableProcessors() / 2), 1)
 }
 
 compilePerfJava {


### PR DESCRIPTION
There doesn't seem to be a true dependency on multi-thread to build.