### PR TITLE
Switched numbers for variables (test smell)

### DIFF
--- a/src/test/java/com/lmax/disruptor/MultiProducerSequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/MultiProducerSequencerTest.java
@@ -22,20 +22,28 @@ import org.junit.Test;
 
 public class MultiProducerSequencerTest
 {
-    private final Sequencer publisher = new MultiProducerSequencer(1024, new BlockingWaitStrategy());
+    
+
+    
+    /* CONSTANTS*/
+    private static final int BUFFER_SIZE = 1024;
+    private static final int AVAILABLE_SEQUENCE_3 = 3;
+    private static final int AVAILABLE_SEQUENCE_5 = 5;
+
+    private final Sequencer publisher = new MultiProducerSequencer(BUFFER_SIZE, new BlockingWaitStrategy());
 
     @Test
     public void shouldOnlyAllowMessagesToBeAvailableIfSpecificallyPublished() throws Exception
     {
-        publisher.publish(3);
-        publisher.publish(5);
+        publisher.publish(AVAILABLE_SEQUENCE_3);
+        publisher.publish(AVAILABLE_SEQUENCE_5);
 
         assertThat(publisher.isAvailable(0), is(false));
         assertThat(publisher.isAvailable(1), is(false));
         assertThat(publisher.isAvailable(2), is(false));
-        assertThat(publisher.isAvailable(3), is(true));
+        assertThat(publisher.isAvailable(AVAILABLE_SEQUENCE_3), is(true));
         assertThat(publisher.isAvailable(4), is(false));
-        assertThat(publisher.isAvailable(5), is(true));
+        assertThat(publisher.isAvailable(AVAILABLE_SEQUENCE_5), is(true));
         assertThat(publisher.isAvailable(6), is(false));
     }
 }

--- a/src/test/java/com/lmax/disruptor/SequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/SequencerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class SequencerTest
 {
+    private static final int INITIAL_SEQUENCER_VALUE = 0;
     private static final int BUFFER_SIZE = 16;
     private final ExecutorService executor = Executors.newSingleThreadExecutor(DaemonThreadFactory.INSTANCE);
 
@@ -47,7 +48,7 @@ public class SequencerTest
     @Test
     public void shouldStartWithInitialValue()
     {
-        assertEquals(0, sequencer.next());
+        assertEquals(INITIAL_SEQUENCER_VALUE, sequencer.next());
     }
 
     @Test

--- a/src/test/java/com/lmax/disruptor/util/UtilTest.java
+++ b/src/test/java/com/lmax/disruptor/util/UtilTest.java
@@ -22,10 +22,15 @@ import org.junit.Test;
 
 public final class UtilTest
 {
+    private static final long HIGHER_VALUE = 12L;
+    private static final long MIDDLE_VALUE = 7L;
+    private static final long LOWER_VALUE = 3L;
+    private static final int VALUE_GRATER_THAN_512_AND_LESS_THAN_1023 = 1000;
+
     @Test
     public void shouldReturnNextPowerOfTwo()
     {
-        int powerOfTwo = Util.ceilingNextPowerOfTwo(1000);
+        int powerOfTwo = Util.ceilingNextPowerOfTwo(VALUE_GRATER_THAN_512_AND_LESS_THAN_1023);
 
         Assert.assertEquals(1024, powerOfTwo);
     }
@@ -41,8 +46,8 @@ public final class UtilTest
     @Test
     public void shouldReturnMinimumSequence()
     {
-        final Sequence[] sequences = {new Sequence(7L), new Sequence(3L), new Sequence(12L)};
-        Assert.assertEquals(3L, Util.getMinimumSequence(sequences));
+        final Sequence[] sequences = {new Sequence(MIDDLE_VALUE), new Sequence(LOWER_VALUE), new Sequence(HIGHER_VALUE)};
+        Assert.assertEquals(LOWER_VALUE, Util.getMinimumSequence(sequences));
     }
 
     @Test


### PR DESCRIPTION
It is a test refactoring.
The idea is to remove the smell Magic Number.
This smell occurs when a test method contains unexplained and undocumented numeric literals as parameters or as values to identifiers. These magic values do not sufficiently indicate the meaning/purpose of the number. 
