### PR TITLE
Add a JMH Benchmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ ext {
 
 sourceSets {
     perf.java.srcDir file('src/perftest/java')
+    jmh
 }
 
 eclipse.classpath.plusConfigurations += [ sourceSets.perf.compileClasspath ]
@@ -55,6 +56,9 @@ dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:8.12'
     testCompile 'junit:junit:4.12'
     perfCompile 'org.hdrhistogram:HdrHistogram:2.1.10'
+    jmhCompile project
+    jmhCompile 'org.openjdk.jmh:jmh-core:1.26'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.26'
 }
 
 idea.module {
@@ -176,6 +180,32 @@ task perfJar(type: Jar) {
     from sourceSets.perf.output
     from sourceSets.test.output
     with jar
+}
+
+task jmh(type: JavaExec, description: 'Executing JMH benchmarks', group: 'performance') {
+    classpath = sourceSets.jmh.runtimeClasspath
+    main = 'org.openjdk.jmh.Main'
+
+    def profilers = ['pauses']
+    def format = 'json'
+    def resultFile = file("build/reports/jmh/result.${format}")
+    resultFile.parentFile.mkdirs()
+
+    args '-rf', format
+    args '-rff', resultFile
+    args '-foe', 'true' //fail-on-error
+    args '-v', 'NORMAL' //verbosity [SILENT, NORMAL, EXTRA]
+    profilers.each {
+        args '-prof', it
+    }
+    args '-jvmArgsPrepend', '-Xmx256m'
+    args '-jvmArgsPrepend', '-Xms256m'
+}
+
+task jmhProfilers(type: JavaExec, description:'Lists the available profilers for the jmh task', group: 'performance') {
+    classpath = sourceSets.jmh.runtimeClasspath
+    main = 'org.openjdk.jmh.Main'
+    args '-lprof'
 }
 
 wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,7 @@ task jmh(type: JavaExec, description: 'Executing JMH benchmarks', group: 'perfor
     }
     args '-jvmArgsPrepend', '-Xmx256m'
     args '-jvmArgsPrepend', '-Xms256m'
+    args '-jvmArgsPrepend', '-XX:MaxDirectMemorySize=1g'
 }
 
 task jmhProfilers(type: JavaExec, description:'Lists the available profilers for the jmh task', group: 'performance') {

--- a/src/jmh/java/com/lmax/disruptor/SimpleBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/SimpleBenchmark.java
@@ -1,0 +1,80 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.Constants;
+import com.lmax.disruptor.util.DaemonThreadFactory;
+import com.lmax.disruptor.util.SimpleEvent;
+import com.lmax.disruptor.util.SimpleEventHandler;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+public class SimpleBenchmark
+{
+    private RingBuffer<SimpleEvent> ringBuffer;
+    private SimpleEventHandler eventHandler;
+    private Disruptor<SimpleEvent> disruptor;
+
+    @Setup
+    public void setup() {
+        disruptor = new Disruptor<>(
+                SimpleEvent::new,
+                Constants.RINGBUFFER_SIZE,
+                DaemonThreadFactory.INSTANCE,
+                ProducerType.SINGLE,
+                new BusySpinWaitStrategy());
+
+        eventHandler = new SimpleEventHandler();
+        disruptor.handleEventsWith(eventHandler);
+
+        ringBuffer = disruptor.start();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(Constants.ITERATIONS)
+    public void publishSimpleEvents() {
+        for (int i = 0; i < Constants.ITERATIONS; i++) {
+            long sequence = ringBuffer.next();
+            SimpleEvent simpleEvent = ringBuffer.get(sequence);
+            simpleEvent.setValue(i);
+            ringBuffer.publish(sequence);
+        }
+
+        while (eventHandler.lastSeenSequence % Constants.ITERATIONS != Constants.ITERATIONS - 1)
+        {
+            Thread.yield();
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        disruptor.shutdown();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(SimpleBenchmark.class.getSimpleName())
+                .threads(4)
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/jmh/java/com/lmax/disruptor/SimpleBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/SimpleBenchmark.java
@@ -76,7 +76,6 @@ public class SimpleBenchmark
     {
         Options opt = new OptionsBuilder()
                 .include(SimpleBenchmark.class.getSimpleName())
-                .threads(4)
                 .forks(1)
                 .build();
         new Runner(opt).run();

--- a/src/jmh/java/com/lmax/disruptor/SimpleBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/SimpleBenchmark.java
@@ -34,9 +34,9 @@ public class SimpleBenchmark
     private Disruptor<SimpleEvent> disruptor;
 
     @Setup
-    public void setup() {
-        disruptor = new Disruptor<>(
-                SimpleEvent::new,
+    public void setup()
+    {
+        disruptor = new Disruptor<>(SimpleEvent::new,
                 Constants.RINGBUFFER_SIZE,
                 DaemonThreadFactory.INSTANCE,
                 ProducerType.SINGLE,
@@ -50,8 +50,10 @@ public class SimpleBenchmark
 
     @Benchmark
     @OperationsPerInvocation(Constants.ITERATIONS)
-    public void publishSimpleEvents() {
-        for (int i = 0; i < Constants.ITERATIONS; i++) {
+    public void publishSimpleEvents()
+    {
+        for (int i = 0; i < Constants.ITERATIONS; i++)
+        {
             long sequence = ringBuffer.next();
             SimpleEvent simpleEvent = ringBuffer.get(sequence);
             simpleEvent.setValue(i);
@@ -65,11 +67,13 @@ public class SimpleBenchmark
     }
 
     @TearDown
-    public void tearDown() {
+    public void tearDown()
+    {
         disruptor.shutdown();
     }
 
-    public static void main(String[] args) throws RunnerException {
+    public static void main(String[] args) throws RunnerException
+    {
         Options opt = new OptionsBuilder()
                 .include(SimpleBenchmark.class.getSimpleName())
                 .threads(4)

--- a/src/jmh/java/com/lmax/disruptor/SingleProducerSingleConsumer.java
+++ b/src/jmh/java/com/lmax/disruptor/SingleProducerSingleConsumer.java
@@ -1,16 +1,18 @@
 package com.lmax.disruptor;
 
+import java.util.concurrent.TimeUnit;
+
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.util.Constants;
 import com.lmax.disruptor.util.DaemonThreadFactory;
 import com.lmax.disruptor.util.SimpleEvent;
 import com.lmax.disruptor.util.SimpleEventHandler;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -22,53 +24,36 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
 @Fork(1)
-public class SimpleBenchmark
+public class SingleProducerSingleConsumer
 {
     private RingBuffer<SimpleEvent> ringBuffer;
     private Disruptor<SimpleEvent> disruptor;
-    private AtomicLong eventsHandled;
 
     @Setup
     public void setup(final Blackhole bh)
     {
-        eventsHandled = new AtomicLong();
-
         disruptor = new Disruptor<>(SimpleEvent::new,
                 Constants.RINGBUFFER_SIZE,
                 DaemonThreadFactory.INSTANCE,
                 ProducerType.SINGLE,
                 new BusySpinWaitStrategy());
 
-        disruptor.handleEventsWith(new SimpleEventHandler(bh, eventsHandled));
+        disruptor.handleEventsWith(new SimpleEventHandler(bh));
 
         ringBuffer = disruptor.start();
     }
 
     @Benchmark
-    @OperationsPerInvocation(Constants.ITERATIONS)
-    public void publishSimpleEvents()
+    public void producing()
     {
-        eventsHandled.set(0);
-
-        for (int i = 0; i < Constants.ITERATIONS; i++)
-        {
-            long sequence = ringBuffer.next();
-            SimpleEvent simpleEvent = ringBuffer.get(sequence);
-            simpleEvent.setValue(i);
-            ringBuffer.publish(sequence);
-        }
-
-        while (eventsHandled.get() != Constants.ITERATIONS)
-        {
-            Thread.yield();
-        }
+        long sequence = ringBuffer.next();
+        SimpleEvent simpleEvent = ringBuffer.get(sequence);
+        simpleEvent.setValue(0);
+        ringBuffer.publish(sequence);
     }
 
     @TearDown
@@ -80,7 +65,7 @@ public class SimpleBenchmark
     public static void main(String[] args) throws RunnerException
     {
         Options opt = new OptionsBuilder()
-                .include(SimpleBenchmark.class.getSimpleName())
+                .include(SingleProducerSingleConsumer.class.getSimpleName())
                 .forks(1)
                 .build();
         new Runner(opt).run();

--- a/src/jmh/java/com/lmax/disruptor/util/Constants.java
+++ b/src/jmh/java/com/lmax/disruptor/util/Constants.java
@@ -1,0 +1,6 @@
+package com.lmax.disruptor.util;
+
+public class Constants {
+    public static final int RINGBUFFER_SIZE = 1 << 20;
+    public static final int ITERATIONS = 1_000_000;
+}

--- a/src/jmh/java/com/lmax/disruptor/util/Constants.java
+++ b/src/jmh/java/com/lmax/disruptor/util/Constants.java
@@ -1,6 +1,7 @@
 package com.lmax.disruptor.util;
 
-public class Constants {
+public class Constants
+{
     public static final int RINGBUFFER_SIZE = 1 << 20;
     public static final int ITERATIONS = 1_000_000;
 }

--- a/src/jmh/java/com/lmax/disruptor/util/SimpleEvent.java
+++ b/src/jmh/java/com/lmax/disruptor/util/SimpleEvent.java
@@ -9,12 +9,14 @@ public class SimpleEvent
         return value;
     }
 
-    public void setValue(final long value) {
+    public void setValue(final long value)
+    {
         this.value = value;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "SimpleEvent{" +
                 "value=" + value +
                 '}';

--- a/src/jmh/java/com/lmax/disruptor/util/SimpleEvent.java
+++ b/src/jmh/java/com/lmax/disruptor/util/SimpleEvent.java
@@ -1,0 +1,22 @@
+package com.lmax.disruptor.util;
+
+public class SimpleEvent
+{
+    private long value = Long.MIN_VALUE;
+
+    public long getValue()
+    {
+        return value;
+    }
+
+    public void setValue(final long value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleEvent{" +
+                "value=" + value +
+                '}';
+    }
+}

--- a/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
+++ b/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
@@ -8,7 +8,8 @@ public class SimpleEventHandler implements EventHandler<SimpleEvent>
 {
     private final AtomicLong eventsHandled;
 
-    public SimpleEventHandler(final AtomicLong eventsHandled) {
+    public SimpleEventHandler(final AtomicLong eventsHandled)
+    {
         this.eventsHandled = eventsHandled;
     }
 

--- a/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
+++ b/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
@@ -1,25 +1,21 @@
 package com.lmax.disruptor.util;
 
 import com.lmax.disruptor.EventHandler;
-import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.concurrent.atomic.AtomicLong;
+import org.openjdk.jmh.infra.Blackhole;
 
 public class SimpleEventHandler implements EventHandler<SimpleEvent>
 {
     private final Blackhole bh;
-    private final AtomicLong eventsHandled;
 
-    public SimpleEventHandler(final Blackhole bh, final AtomicLong eventsHandled)
+    public SimpleEventHandler(final Blackhole bh)
     {
         this.bh = bh;
-        this.eventsHandled = eventsHandled;
     }
 
     @Override
     public void onEvent(final SimpleEvent event, final long sequence, final boolean endOfBatch)
     {
-        eventsHandled.incrementAndGet();
         bh.consume(event);
     }
 }

--- a/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
+++ b/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
@@ -1,21 +1,25 @@
 package com.lmax.disruptor.util;
 
 import com.lmax.disruptor.EventHandler;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 public class SimpleEventHandler implements EventHandler<SimpleEvent>
 {
+    private final Blackhole bh;
     private final AtomicLong eventsHandled;
 
-    public SimpleEventHandler(final AtomicLong eventsHandled)
+    public SimpleEventHandler(final Blackhole bh, final AtomicLong eventsHandled)
     {
+        this.bh = bh;
         this.eventsHandled = eventsHandled;
     }
 
     @Override
-    public void onEvent(SimpleEvent event, long sequence, boolean endOfBatch)
+    public void onEvent(final SimpleEvent event, final long sequence, final boolean endOfBatch)
     {
         eventsHandled.incrementAndGet();
+        bh.consume(event);
     }
 }

--- a/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
+++ b/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
@@ -2,13 +2,19 @@ package com.lmax.disruptor.util;
 
 import com.lmax.disruptor.EventHandler;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class SimpleEventHandler implements EventHandler<SimpleEvent>
 {
-    public long lastSeenSequence = Long.MIN_VALUE;
+    private final AtomicLong eventsHandled;
+
+    public SimpleEventHandler(final AtomicLong eventsHandled) {
+        this.eventsHandled = eventsHandled;
+    }
 
     @Override
     public void onEvent(SimpleEvent event, long sequence, boolean endOfBatch)
     {
-        lastSeenSequence = sequence;
+        eventsHandled.incrementAndGet();
     }
 }

--- a/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
+++ b/src/jmh/java/com/lmax/disruptor/util/SimpleEventHandler.java
@@ -1,0 +1,14 @@
+package com.lmax.disruptor.util;
+
+import com.lmax.disruptor.EventHandler;
+
+public class SimpleEventHandler implements EventHandler<SimpleEvent>
+{
+    public long lastSeenSequence = Long.MIN_VALUE;
+
+    @Override
+    public void onEvent(SimpleEvent event, long sequence, boolean endOfBatch)
+    {
+        lastSeenSequence = sequence;
+    }
+}


### PR DESCRIPTION
All current performance tests appear to be written before JMH existed and relies on building a separate jar which gives results in a non-standard format.
We should use JMH and leverage the way it works and the profilers it comes with instead.

This is just testing the waters, converting `SimplePerformanceTest` only, before jumping in and writing more JMH benchmarks.
I am not well versed in writing JMH benchmarks so review welcome.

(Note: we can also pass the JMH run some JVM args to make it similar to `runme.sh`)