### PR TITLE
Exclude currently intermittent tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,3 +191,9 @@ class Version {
         "$major.$minor.$revision${stage ? '.' + stage : ''}${snapshot ? '-SNAPSHOT' : ''}"
     }
 }
+
+test {
+    useJUnit {
+        excludeCategories 'com.lmax.disruptor.IntermittentTests'
+    }
+}

--- a/src/test/java/com/lmax/disruptor/IntermittentTests.java
+++ b/src/test/java/com/lmax/disruptor/IntermittentTests.java
@@ -1,0 +1,5 @@
+package com.lmax.disruptor;
+
+public interface IntermittentTests
+{
+}

--- a/src/test/java/com/lmax/disruptor/RemoveWorkHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/RemoveWorkHandlerTest.java
@@ -20,14 +20,20 @@ import com.lmax.disruptor.support.StubEvent;
 import com.lmax.disruptor.util.DaemonThreadFactory;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class RemoveWorkHandlerTest
 {
     @Test
+    @Category(IntermittentTests.class)
     public void removeWorkHandlerLostEventExample() throws InterruptedException
     {
         int eventSize = 8;

--- a/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
@@ -23,6 +23,7 @@ import com.lmax.disruptor.EventTranslator;
 import com.lmax.disruptor.EventTranslatorOneArg;
 import com.lmax.disruptor.ExceptionHandler;
 import com.lmax.disruptor.FatalExceptionHandler;
+import com.lmax.disruptor.IntermittentTests;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.Sequence;
 import com.lmax.disruptor.SequenceBarrier;
@@ -40,6 +41,7 @@ import com.lmax.disruptor.support.TestEvent;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -53,12 +55,7 @@ import static java.lang.Thread.yield;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @SuppressWarnings(value = {"unchecked"})
 public class DisruptorTest
@@ -596,6 +593,7 @@ public class DisruptorTest
     }
 
     @Test
+    @Category(IntermittentTests.class)
     public void shouldProvideEventsToWorkHandlers() throws Exception
     {
         final TestWorkHandler workHandler1 = createTestWorkHandler();
@@ -669,6 +667,7 @@ public class DisruptorTest
     }
 
     @Test
+    @Category(IntermittentTests.class)
     public void shouldSupportUsingWorkerPoolWithADependency() throws Exception
     {
         final TestWorkHandler workHandler1 = createTestWorkHandler();


### PR DESCRIPTION
Add an `IntermittentTests` category and exclude tests categorised as such when running in CI until they get fixed.
Hopefully this should stop CI failing every other commit, but the tests are still fine to run locally rather than being ignored.