### PR TITLE
Fix intermittent tests in DisruptorTest

### DIFF
--- a/src/main/java/com/lmax/disruptor/WorkProcessor.java
+++ b/src/main/java/com/lmax/disruptor/WorkProcessor.java
@@ -39,7 +39,8 @@ public final class WorkProcessor<T>
 
     private final TimeoutHandler timeoutHandler;
 
-    private enum RunState {
+    private enum RunState
+    {
         IDLE,
         RUNNING,
         HALTED

--- a/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
@@ -37,7 +37,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -50,7 +49,12 @@ import static java.lang.Thread.yield;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings(value = {"unchecked"})
 public class DisruptorTest

--- a/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
@@ -20,7 +20,6 @@ import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.ExceptionHandler;
 import com.lmax.disruptor.FatalExceptionHandler;
-import com.lmax.disruptor.IntermittentTests;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.SequenceBarrier;
 import com.lmax.disruptor.TimeoutException;
@@ -543,7 +542,6 @@ public class DisruptorTest
     }
 
     @Test
-    @Category(IntermittentTests.class)
     public void shouldProvideEventsToWorkHandlers() throws Exception
     {
         final TestWorkHandler workHandler1 = createTestWorkHandler();
@@ -617,7 +615,6 @@ public class DisruptorTest
     }
 
     @Test
-    @Category(IntermittentTests.class)
     public void shouldSupportUsingWorkerPoolWithADependency() throws Exception
     {
         final TestWorkHandler workHandler1 = createTestWorkHandler();

--- a/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
@@ -36,6 +36,7 @@ import com.lmax.disruptor.dsl.stubs.TestWorkHandler;
 import com.lmax.disruptor.support.TestEvent;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -43,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -58,10 +58,12 @@ public class DisruptorTest
 {
     private static final int TIMEOUT_IN_SECONDS = 2;
 
+    @Rule
+    public final StubThreadFactory executor = new StubThreadFactory();
+
     private final Collection<DelayedEventHandler> delayedEventHandlers = new ArrayList<>();
     private final Collection<TestWorkHandler> testWorkHandlers = new ArrayList<>();
     private Disruptor<TestEvent> disruptor;
-    private StubThreadFactory executor;
     private RingBuffer<TestEvent> ringBuffer;
     private TestEvent lastPublishedEvent;
 
@@ -806,15 +808,12 @@ public class DisruptorTest
 
     private void createDisruptor()
     {
-        executor = new StubThreadFactory();
-        createDisruptor(executor);
-    }
-
-    private void createDisruptor(final ThreadFactory threadFactory)
-    {
         disruptor = new Disruptor<>(
-                TestEvent.EVENT_FACTORY, 4, threadFactory,
-                ProducerType.SINGLE, new BlockingWaitStrategy());
+                TestEvent.EVENT_FACTORY,
+                4,
+                executor,
+                ProducerType.SINGLE,
+                new BlockingWaitStrategy());
     }
 
     private TestEvent publishEvent() throws InterruptedException, BrokenBarrierException

--- a/src/test/java/com/lmax/disruptor/dsl/stubs/StubThreadFactory.java
+++ b/src/test/java/com/lmax/disruptor/dsl/stubs/StubThreadFactory.java
@@ -42,7 +42,8 @@ public final class StubThreadFactory implements ThreadFactory, TestRule
     public Thread newThread(final Runnable command)
     {
         executionCount.getAndIncrement();
-        Runnable toExecute = () -> {
+        Runnable toExecute = () ->
+        {
             try
             {
                 command.run();


### PR DESCRIPTION
As mentioned in #308 the WorkProcessor had a bug where if `halt` was called before the thread had begun executing, the WorkProcessor will set running to true and run forever (or until `halt` called again at least).

We have added a `RunState` enum with an `AtomicReference` so that if run is called after the state has moved to `HALTED` we do not run.

The two tests that were intermittent in `DisruptorTest` are no longer intermittent.