### PR TITLE
Retrospectively change the meaning of halt on WorkProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  - Breaking Changes
     - Minimum Java version now 11
+    - `WorkerPool::halt` and `WorkerPool::drainAndHalt` will now permanently halt the `WorkerPool`
     - `WorkProcessor::halt` and `WorkProcessor::haltLater` will now permanently halt the `WorkProcessor`
 
 ## 3.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.0 - Not yet released
+
+ - Breaking Changes
+    - Minimum Java version now 11
+    - `WorkProcessor::halt` and `WorkProcessor::haltLater` will now permanently halt the `WorkProcessor`
+
 ## 3.4.2
 
 - Fix race condition in BatchEventProcessor with 3 or more starting/halting concurrently.

--- a/src/main/java/com/lmax/disruptor/RunState.java
+++ b/src/main/java/com/lmax/disruptor/RunState.java
@@ -1,0 +1,8 @@
+package com.lmax.disruptor;
+
+enum RunState
+{
+    IDLE,
+    RUNNING,
+    HALTED
+}

--- a/src/main/java/com/lmax/disruptor/WorkProcessor.java
+++ b/src/main/java/com/lmax/disruptor/WorkProcessor.java
@@ -39,13 +39,6 @@ public final class WorkProcessor<T>
 
     private final TimeoutHandler timeoutHandler;
 
-    private enum RunState
-    {
-        IDLE,
-        RUNNING,
-        HALTED
-    }
-
     private final AtomicReference<RunState> runState = new AtomicReference<>(RunState.IDLE);
 
     /**

--- a/src/main/java/com/lmax/disruptor/WorkProcessor.java
+++ b/src/main/java/com/lmax/disruptor/WorkProcessor.java
@@ -107,9 +107,9 @@ public final class WorkProcessor<T>
     }
 
     /**
-     * It is ok to have another thread re-run this method after a halt().
+     * Once a WorkProcessor has been halted it should never be re-run.
      *
-     * @throws IllegalStateException if this processor is already running
+     * @throws IllegalStateException if this processor is anything other than IDLE
      */
     @Override
     public void run()
@@ -118,11 +118,11 @@ public final class WorkProcessor<T>
         {
             if (runState.get() == RunState.RUNNING)
             {
-                throw new IllegalStateException("Thread is already running");
+                throw new IllegalStateException("WorkProcessor is already running");
             }
             else
             {
-                return;
+                throw new IllegalStateException("Cannot run a WorkProcessor that has been halted");
             }
         }
         sequenceBarrier.clearAlert();

--- a/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/DisruptorTest.java
@@ -557,6 +557,10 @@ public class DisruptorTest
 
         workHandler1.processEvent();
         workHandler2.processEvent();
+
+        executor.ignoreException(
+                "Cannot run a WorkProcessor that has been halted",
+                "Teardown may call halt on the WorkProcessor before it is started");
     }
 
 
@@ -634,6 +638,10 @@ public class DisruptorTest
 
         workHandler1.processEvent();
         workHandler2.processEvent();
+
+        executor.ignoreException(
+                "Cannot run a WorkProcessor that has been halted",
+                "Teardown may call halt on the WorkProcessor before it is started");
     }
 
     @Test

--- a/src/test/java/com/lmax/disruptor/dsl/stubs/StubThreadFactory.java
+++ b/src/test/java/com/lmax/disruptor/dsl/stubs/StubThreadFactory.java
@@ -144,7 +144,7 @@ public final class StubThreadFactory implements ThreadFactory, TestRule
         final String exceptionMessage;
         final String reason;
 
-        public IgnoredException(final String exceptionMessage, final String reason)
+        IgnoredException(final String exceptionMessage, final String reason)
         {
             this.exceptionMessage = exceptionMessage;
             this.reason = reason;


### PR DESCRIPTION
Our previous intermittency fix changed the meaning of `WorkProcessor::halt` and we should have updated the documentation to reflect that breaking change.