### PR TITLE
No more need for the IntermittentTests category

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,12 +245,6 @@ class Version {
     }
 }
 
-test {
-    useJUnit {
-        excludeCategories 'com.lmax.disruptor.IntermittentTests'
-    }
-}
-
 task setUpGitHooks(type: Exec, description: 'Add a pre-commit git hook that runs gradle check & test tasks') {
     def hooksFolder = file('.githooks').getAbsolutePath()
     commandLine 'git', 'config','core.hooksPath',hooksFolder

--- a/src/test/java/com/lmax/disruptor/IntermittentTests.java
+++ b/src/test/java/com/lmax/disruptor/IntermittentTests.java
@@ -1,5 +1,0 @@
-package com.lmax.disruptor;
-
-public interface IntermittentTests
-{
-}


### PR DESCRIPTION
`WorkerPool` and friends used to be the source of intermittent unit tests due to race conditions.

Since we have removed these classes and their associated tests, I have not seen any intermittent test failures locally or in CI.