### PR TITLE
Gradle refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,18 +48,12 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:8.12'
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
-
-    perftestImplementation 'org.hdrhistogram:HdrHistogram:2.1.10'
-
-    jmhImplementation 'org.openjdk.jmh:jmh-core:1.26'
-    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.26'
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -14,40 +14,19 @@
  * limitations under the License.
  */
 plugins {
-    id 'java'
-    id 'maven'
+    id 'java-library'
+    id 'maven-publish'
     id 'signing'
-    id 'eclipse' // Only used so the Eclipse STS Gradle plugin can see the 'perf' source set dependencies. :-(
     id 'checkstyle'
     id 'idea'
 
     id 'org.asciidoctor.jvm.convert' version '3.1.0'
 }
 
-asciidoctor {
-    languages 'en'
-    resources {
-        from(javadoc) {
-            into './javadoc'
-        }
-        from('src/docs/resources') {
-            into './resources'
-        }
-        from('src/docs/files') {
-            into './files'
-        }
-    }
-    attributes 'source-highlighter': 'coderay',
-            'toc': 'left',
-            'xrefstyle': 'short'
-    copyResourcesOnlyIf 'html5'
-    baseDirFollowsSourceFile()
-}
+group = 'com.lmax'
+version = new Version(major: 4, minor: 0, revision: 0, snapshot: true)
 
 defaultTasks 'build'
-
-group = 'com.lmax'
-version = new Version(major: 3, minor: 4, revision: 3)
 
 ext {
     fullName = 'Disruptor Framework'
@@ -56,59 +35,39 @@ ext {
     siteUrl = 'http://lmax-exchange.github.com/disruptor'
     sourceUrl = 'git@github.com:LMAX-Exchange/disruptor.git'
     moduleName = 'com.lmax.disruptor'
-
-    javaCompilerExecutable = System.env['JAVA_HOME'] ? System.env['JAVA_HOME'] + '/bin/javac' : 'javac'
-
-    if (!project.hasProperty('sonatypeUrl')) sonatypeUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-    if (!project.hasProperty('sonatypeUsername')) sonatypeUsername = ''
-    if (!project.hasProperty('sonatypePassword')) sonatypePassword = ''
 }
 
-sourceSets {
-    perf.java.srcDir file('src/perftest/java')
-    jmh
-}
+apply from: 'gradle/maven.gradle'
+apply from: 'gradle/perf.gradle'
+apply from: 'gradle/jmh.gradle'
+apply from: 'gradle/asciidoc.gradle'
 
-eclipse.classpath.plusConfigurations += [sourceSets.perf.compileClasspath]
+wrapper.gradleVersion = '6.5'
 
 repositories {
     mavenCentral()
 }
 
-dependencies {
-    checkstyle 'com.puppycrawl.tools:checkstyle:8.12'
-    testCompile 'org.junit.vintage:junit-vintage-engine:5.7.0'
-    perfCompile 'org.hdrhistogram:HdrHistogram:2.1.10'
-    jmhCompile project
-    jmhCompile 'org.openjdk.jmh:jmh-core:1.26'
-    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.26'
-}
-
-idea.module {
-    testSourceDirs += sourceSets.perf.allSource.srcDirs
-    scopes.TEST.plus += [configurations.perfCompile]
-}
-
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
+dependencies {
+    checkstyle 'com.puppycrawl.tools:checkstyle:8.12'
+
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
+
+    perftestImplementation 'org.hdrhistogram:HdrHistogram:2.1.10'
+
+    jmhImplementation 'org.openjdk.jmh:jmh-core:1.26'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.26'
+}
 
 compileJava {
     // Suppress warnings about using Unsafe and sun.misc
     options.compilerArgs << '-XDignore.symbol.file'
     options.fork = true
     options.debug = true
-    options.forkOptions.executable = javaCompilerExecutable
     options.warnings = false
-}
-
-tasks.withType(Test) {
-    maxParallelForks = Math.max(Math.floor(Runtime.runtime.availableProcessors() / 2), 1)
-}
-
-compilePerfJava {
-    classpath += sourceSets.main.runtimeClasspath
-    classpath += sourceSets.test.runtimeClasspath
 }
 
 javadoc {
@@ -131,107 +90,13 @@ jar {
             'Automatic-Module-Name': moduleName)
 }
 
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+tasks.withType(Test) {
+    maxParallelForks = Math.max(Math.floor(Runtime.runtime.availableProcessors() / 2), 1)
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourcesJar, javadocJar
-}
-
-def projectPom = {
-    name = fullName
-    description = fullDescription
-    url = siteUrl
-
-    scm {
-        url = "scm:$sourceUrl"
-        connection = "scm:$sourceUrl"
-    }
-
-    licenses {
-        license {
-            name = 'The Apache Software License, Version 2.0'
-            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-            distribution = 'repo'
-        }
-    }
-
-    developers {
-        developer {
-            id = 'team'
-            name = teamName
-            email = 'lmax-disruptor@googlegroups.com'
-        }
-    }
-}
-
-install {
-    repositories.mavenInstaller.pom.project(projectPom)
-}
-
-signing {
-    required { gradle.taskGraph.hasTask('uploadArchives') }
-    sign configurations.archives
-}
-
-uploadArchives {
-    repositories.mavenDeployer {
-        beforeDeployment { deployment -> signing.signPom(deployment) }
-
-        repository(url: sonatypeUrl) {
-            authentication(userName: sonatypeUsername, password: sonatypePassword)
-        }
-
-        pom.project(projectPom)
-    }
-}
-
-build.dependsOn perfClasses
-
-task perfJar(type: Jar) {
-    baseName = project.name + '-perf'
-    from { configurations.perfCompile.collect { it.isDirectory() ? it : zipTree(it) } }
-    from sourceSets.perf.output
-    from sourceSets.test.output
-    with jar
-}
-
-task jmh(type: JavaExec, description: 'Executing JMH benchmarks', group: 'performance') {
-    classpath = sourceSets.jmh.runtimeClasspath
-    main = 'org.openjdk.jmh.Main'
-
-    def profilers = ['pauses']
-    def format = 'json'
-    def resultFile = file("build/reports/jmh/result.${format}")
-    resultFile.parentFile.mkdirs()
-
-    args '-rf', format
-    args '-rff', resultFile
-    args '-foe', 'true' //fail-on-error
-    args '-v', 'NORMAL' //verbosity [SILENT, NORMAL, EXTRA]
-    profilers.each {
-        args '-prof', it
-    }
-    args '-jvmArgsPrepend', '-Xmx256m'
-    args '-jvmArgsPrepend', '-Xms256m'
-    args '-jvmArgsPrepend', '-XX:MaxDirectMemorySize=1g'
-}
-
-task jmhProfilers(type: JavaExec, description:'Lists the available profilers for the jmh task', group: 'performance') {
-    classpath = sourceSets.jmh.runtimeClasspath
-    main = 'org.openjdk.jmh.Main'
-    args '-lprof'
-}
-
-wrapper {
-    gradleVersion = '6.5'
+task setUpGitHooks(type: Exec, description: 'Add a pre-commit git hook that runs gradle check & test tasks') {
+    def hooksFolder = file('.githooks').getAbsolutePath()
+    commandLine 'git', 'config', 'core.hooksPath', hooksFolder
 }
 
 class Version {
@@ -242,9 +107,4 @@ class Version {
     String toString() {
         "$major.$minor.$revision${stage ? '.' + stage : ''}${snapshot ? '-SNAPSHOT' : ''}"
     }
-}
-
-task setUpGitHooks(type: Exec, description: 'Add a pre-commit git hook that runs gradle check & test tasks') {
-    def hooksFolder = file('.githooks').getAbsolutePath()
-    commandLine 'git', 'config','core.hooksPath',hooksFolder
 }

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -1,0 +1,23 @@
+//
+// Configure ASCIIDoc publishing
+//
+
+asciidoctor {
+    languages 'en'
+    resources {
+        from(javadoc) {
+            into './javadoc'
+        }
+        from('src/docs/resources') {
+            into './resources'
+        }
+        from('src/docs/files') {
+            into './files'
+        }
+    }
+    attributes 'source-highlighter': 'coderay',
+            'toc': 'left',
+            'xrefstyle': 'short'
+    copyResourcesOnlyIf 'html5'
+    baseDirFollowsSourceFile()
+}

--- a/gradle/jmh.gradle
+++ b/gradle/jmh.gradle
@@ -9,6 +9,11 @@ sourceSets {
     }
 }
 
+dependencies {
+    jmhImplementation 'org.openjdk.jmh:jmh-core:1.26'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.26'
+}
+
 task jmh(type: JavaExec, description: 'Executing JMH benchmarks', group: 'performance') {
     classpath = sourceSets.jmh.runtimeClasspath
     main = 'org.openjdk.jmh.Main'

--- a/gradle/jmh.gradle
+++ b/gradle/jmh.gradle
@@ -1,0 +1,38 @@
+//
+// Configure JMH benchmarks
+//
+
+sourceSets {
+    jmh {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+task jmh(type: JavaExec, description: 'Executing JMH benchmarks', group: 'performance') {
+    classpath = sourceSets.jmh.runtimeClasspath
+    main = 'org.openjdk.jmh.Main'
+
+    def profilers = ['pauses']
+    def format = 'json'
+    def resultFile = file("build/reports/jmh/result.${format}")
+    resultFile.parentFile.mkdirs()
+
+    args '-rf', format
+    args '-rff', resultFile
+    args '-foe', 'true' //fail-on-error
+    args '-v', 'NORMAL' //verbosity [SILENT, NORMAL, EXTRA]
+    profilers.each {
+        args '-prof', it
+    }
+    args '-jvmArgsPrepend', '-Xmx256m'
+    args '-jvmArgsPrepend', '-Xms256m'
+    args '-jvmArgsPrepend', '-XX:MaxDirectMemorySize=1g'
+}
+
+
+task jmhProfilers(type: JavaExec, description:'Lists the available profilers for the jmh task', group: 'performance') {
+    classpath = sourceSets.jmh.runtimeClasspath
+    main = 'org.openjdk.jmh.Main'
+    args '-lprof'
+}

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,0 +1,59 @@
+//
+// Configure publishing to Maven
+//
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+publishing {
+    publications {
+        disruptor(MavenPublication) {
+            from components.java
+
+            pom {
+                name = project.ext.fullName
+                description = project.ext.fullDescription
+                url = project.ext.siteUrl
+
+                scm {
+                    url = "scm:${project.ext.sourceUrl}"
+                    connection = "scm:${project.ext.sourceUrl}"
+                }
+
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'team'
+                        name = teamName
+                        email = 'lmax-disruptor@googlegroups.com'
+                    }
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            url project.hasProperty('sonatypeUrl') ? project['sonatypeUrl'] : 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+
+            credentials {
+                username = project.hasProperty('sonatypeUsername') ? project['sonatypeUsername'] : 'fake-user'
+                password = project.hasProperty('sonatypePassword') ? project['sonatypePassword'] : 'fake-password'
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.disruptor
+}
+
+uploadArchives.dependsOn publish

--- a/gradle/perf.gradle
+++ b/gradle/perf.gradle
@@ -11,6 +11,10 @@ compilePerftestJava {
     classpath += sourceSets.test.runtimeClasspath
 }
 
+dependencies {
+    perftestImplementation 'org.hdrhistogram:HdrHistogram:2.1.10'
+}
+
 build.dependsOn perftestClasses
 
 task perfJar(type: Jar, group: 'build') {

--- a/gradle/perf.gradle
+++ b/gradle/perf.gradle
@@ -1,0 +1,34 @@
+//
+// Configure setting up performance tests
+//
+
+sourceSets {
+    perftest.java.srcDir file('src/perftest/java')
+}
+
+compilePerftestJava {
+    classpath += sourceSets.main.runtimeClasspath
+    classpath += sourceSets.test.runtimeClasspath
+}
+
+build.dependsOn perftestClasses
+
+task perfJar(type: Jar, group: 'build') {
+    archiveAppendix = 'perf'
+    from { configurations.perftestCompile.collect { it.isDirectory() ? it : zipTree(it) } }
+    from sourceSets.perftest.output
+    from sourceSets.test.output
+    with jar
+}
+
+
+project.pluginManager.withPlugin('idea') {
+    idea.module {
+        testSourceDirs += sourceSets.perftest.allSource.srcDirs
+        scopes.TEST.plus += [configurations.perftestCompile]
+    }
+}
+
+project.pluginManager.withPlugin('eclipse') {
+    eclipse.classpath.plusConfigurations += [sourceSets.perftest.compileClasspath]
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/LMAX-Exchange/disruptor/pull/329 and contains all the changes in that PR plus some extra refactoring of the Gradle scripts.

I'm not sure if the suggested refactoring will be to everyone's tastes, so submitting these separately so it's slightly easier to review. If everyone is happy with the changes, they can either be incorporated into the above PR (if it is still waiting to be merged), or merged separately via this request.

There overall aim of this change is to tidy up, modernise and simplify the Gradle build script. 

The key changes are:

- replace the `java` plugin with `java-library`;
- replace the `maven` plugin with `maven-publish`;
- split (most) "non-core" build functionality (i.e. anything that isn't needed to just build the `.jar`) out into separate `.gradle` files for clarity and easier management

I've also removed the explicit import of the `eclipse` plugin. Although I'm not 100% sure about this, I believe that modern versions of both Eclipse and IDEA implicitly import their respective plugins when loading a Gradle project. Since it seemed that `eclipse` was only imported for a specific use-case, it seemed like it could be removed and, worst-case, manually added back in if anyone is actually using Eclipse.