### PR TITLE
Switch to standard Junit5 engine dependency and rewrite tests accordingly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:8.12'
-
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11
 dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:8.12'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 compileJava {

--- a/src/test/java/com/lmax/disruptor/AggregateEventHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/AggregateEventHandlerTest.java
@@ -16,10 +16,10 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.DummyEventHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 @SuppressWarnings("unchecked")
 public final class AggregateEventHandlerTest

--- a/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
+++ b/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
@@ -16,28 +16,38 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.StubEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.lmax.disruptor.RingBuffer.createMultiProducer;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class BatchEventProcessorTest
 {
     private final RingBuffer<StubEvent> ringBuffer = createMultiProducer(StubEvent.EVENT_FACTORY, 16);
     private final SequenceBarrier sequenceBarrier = ringBuffer.newBarrier();
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowExceptionOnSettingNullExceptionHandler()
     {
-        final BatchEventProcessor<StubEvent> batchEventProcessor = new BatchEventProcessor<>(
-                ringBuffer, sequenceBarrier, new ExceptionEventHandler());
-        batchEventProcessor.setExceptionHandler(null);
+        assertThrows(NullPointerException.class, () ->
+        {
+            final BatchEventProcessor<StubEvent> batchEventProcessor = new BatchEventProcessor<>(
+                    ringBuffer, sequenceBarrier, new ExceptionEventHandler());
+            batchEventProcessor.setExceptionHandler(null);
+        });
     }
 
     @Test

--- a/src/test/java/com/lmax/disruptor/BusySpinWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/BusySpinWaitStrategyTest.java
@@ -15,9 +15,9 @@
  */
 package com.lmax.disruptor;
 
-import static com.lmax.disruptor.support.WaitStrategyTestUtil.assertWaitForWithDelayOf;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static com.lmax.disruptor.support.WaitStrategyTestUtil.assertWaitForWithDelayOf;
 
 public class BusySpinWaitStrategyTest
 {

--- a/src/test/java/com/lmax/disruptor/DisruptorStressTest.java
+++ b/src/test/java/com/lmax/disruptor/DisruptorStressTest.java
@@ -3,7 +3,7 @@ package com.lmax.disruptor;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.util.DaemonThreadFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -14,7 +14,7 @@ import java.util.concurrent.locks.LockSupport;
 import static java.lang.Math.max;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DisruptorStressTest
 {

--- a/src/test/java/com/lmax/disruptor/EventPollerTest.java
+++ b/src/test/java/com/lmax/disruptor/EventPollerTest.java
@@ -1,12 +1,12 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.EventPoller.PollState;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class EventPollerTest
 {

--- a/src/test/java/com/lmax/disruptor/EventPublisherTest.java
+++ b/src/test/java/com/lmax/disruptor/EventPublisherTest.java
@@ -15,13 +15,12 @@
  */
 package com.lmax.disruptor;
 
+import com.lmax.disruptor.support.LongEvent;
+import org.junit.jupiter.api.Test;
+
 import static com.lmax.disruptor.RingBuffer.createMultiProducer;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
-
-import com.lmax.disruptor.support.LongEvent;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EventPublisherTest implements EventTranslator<LongEvent>
 {

--- a/src/test/java/com/lmax/disruptor/EventTranslatorTest.java
+++ b/src/test/java/com/lmax/disruptor/EventTranslatorTest.java
@@ -16,8 +16,9 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.StubEvent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class EventTranslatorTest
 {
@@ -31,7 +32,7 @@ public final class EventTranslatorTest
 
         eventTranslator.translateTo(event, 0);
 
-        Assert.assertEquals(TEST_VALUE, event.getTestString());
+        assertEquals(TEST_VALUE, event.getTestString());
     }
 
     public static final class ExampleEventTranslator

--- a/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
@@ -16,8 +16,9 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.TestEvent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class FatalExceptionHandlerTest
 {
@@ -35,7 +36,7 @@ public final class FatalExceptionHandlerTest
         }
         catch (RuntimeException ex)
         {
-            Assert.assertEquals(causeException, ex.getCause());
+            assertEquals(causeException, ex.getCause());
         }
     }
 }

--- a/src/test/java/com/lmax/disruptor/FixedSequenceGroupTest.java
+++ b/src/test/java/com/lmax/disruptor/FixedSequenceGroupTest.java
@@ -15,10 +15,10 @@
  */
 package com.lmax.disruptor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class FixedSequenceGroupTest

--- a/src/test/java/com/lmax/disruptor/IgnoreExceptionHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/IgnoreExceptionHandlerTest.java
@@ -16,7 +16,7 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.TestEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class IgnoreExceptionHandlerTest
 {

--- a/src/test/java/com/lmax/disruptor/LifecycleAwareTest.java
+++ b/src/test/java/com/lmax/disruptor/LifecycleAwareTest.java
@@ -16,13 +16,13 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.StubEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
 import static com.lmax.disruptor.RingBuffer.createMultiProducer;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public final class LifecycleAwareTest
 {

--- a/src/test/java/com/lmax/disruptor/LiteTimeoutBlockingWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/LiteTimeoutBlockingWaitStrategyTest.java
@@ -1,12 +1,12 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.DummySequenceBarrier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LiteTimeoutBlockingWaitStrategyTest
 {

--- a/src/test/java/com/lmax/disruptor/MultiProducerSequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/MultiProducerSequencerTest.java
@@ -15,10 +15,10 @@
  */
 package com.lmax.disruptor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiProducerSequencerTest
 {

--- a/src/test/java/com/lmax/disruptor/PhasedBackoffWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/PhasedBackoffWaitStrategyTest.java
@@ -15,10 +15,11 @@
  */
 package com.lmax.disruptor;
 
+import org.junit.jupiter.api.Test;
+
 import static com.lmax.disruptor.support.WaitStrategyTestUtil.assertWaitForWithDelayOf;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-import org.junit.Test;
 
 public class PhasedBackoffWaitStrategyTest
 {

--- a/src/test/java/com/lmax/disruptor/RingBufferEventMatcher.java
+++ b/src/test/java/com/lmax/disruptor/RingBufferEventMatcher.java
@@ -1,7 +1,6 @@
 package com.lmax.disruptor;
 
 import org.hamcrest.Description;
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
@@ -16,13 +15,11 @@ final class RingBufferEventMatcher extends TypeSafeMatcher<RingBuffer<Object[]>>
         this.expectedValueMatchers = expectedValueMatchers;
     }
 
-    @Factory
     public static RingBufferEventMatcher ringBufferWithEvents(final Matcher<?>... valueMatchers)
     {
         return new RingBufferEventMatcher(valueMatchers);
     }
 
-    @Factory
     public static RingBufferEventMatcher ringBufferWithEvents(final Object... values)
     {
         Matcher<?>[] valueMatchers = new Matcher[values.length];

--- a/src/test/java/com/lmax/disruptor/RingBufferTest.java
+++ b/src/test/java/com/lmax/disruptor/RingBufferTest.java
@@ -15,15 +15,10 @@
  */
 package com.lmax.disruptor;
 
-import static com.lmax.disruptor.RingBuffer.createMultiProducer;
-import static com.lmax.disruptor.RingBufferEventMatcher.ringBufferWithEvents;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import com.lmax.disruptor.support.StubEvent;
+import com.lmax.disruptor.support.TestWaiter;
+import com.lmax.disruptor.util.DaemonThreadFactory;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
@@ -34,11 +29,16 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
-
-import com.lmax.disruptor.support.StubEvent;
-import com.lmax.disruptor.support.TestWaiter;
-import com.lmax.disruptor.util.DaemonThreadFactory;
+import static com.lmax.disruptor.RingBuffer.createMultiProducer;
+import static com.lmax.disruptor.RingBufferEventMatcher.ringBufferWithEvents;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RingBufferTest
 {
@@ -270,22 +270,25 @@ public class RingBufferTest
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsIfBatchIsLargerThanRingBuffer() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        final EventTranslator<Object[]> eventTranslator = new NoArgEventTranslator();
-        final EventTranslator<Object[]>[] translators =
-            new EventTranslator[]{eventTranslator, eventTranslator, eventTranslator, eventTranslator, eventTranslator};
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            final EventTranslator<Object[]> eventTranslator = new NoArgEventTranslator();
+            final EventTranslator<Object[]>[] translators =
+                    new EventTranslator[]{eventTranslator, eventTranslator, eventTranslator, eventTranslator, eventTranslator};
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translators);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translators);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
@@ -333,20 +336,23 @@ public class RingBufferTest
         assertThat(ringBuffer, ringBufferWithEvents("Foo-0", "Foo-1", "Foo-2", "Foo-3"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsOneArgIfBatchIsLargerThanRingBuffer() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, new String[]{"Foo", "Foo", "Foo", "Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, new String[]{"Foo", "Foo", "Foo", "Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @Test
@@ -388,23 +394,26 @@ public class RingBufferTest
         assertThat(ringBuffer, ringBufferWithEvents("FooBar-0", "FooBar-1", "FooBar-2", "FooBar-3"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsITwoArgIfBatchSizeIsBiggerThanRingBuffer() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator,
-                new String[]{"Foo", "Foo", "Foo", "Foo", "Foo"},
-                new String[]{"Bar", "Bar", "Bar", "Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator,
+                        new String[]{"Foo", "Foo", "Foo", "Foo", "Foo"},
+                        new String[]{"Bar", "Bar", "Bar", "Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @Test
@@ -450,24 +459,27 @@ public class RingBufferTest
         assertThat(ringBuffer, ringBufferWithEvents("FooBarBaz-0", "FooBarBaz-1", "FooBarBaz-2", "FooBarBaz-3"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsThreeArgIfBatchIsLargerThanRingBuffer() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator,
-                new String[]{"Foo", "Foo", "Foo", "Foo", "Foo"},
-                new String[]{"Bar", "Bar", "Bar", "Bar", "Bar"},
-                new String[]{"Baz", "Baz", "Baz", "Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator,
+                        new String[]{"Foo", "Foo", "Foo", "Foo", "Foo"},
+                        new String[]{"Bar", "Bar", "Bar", "Bar", "Bar"},
+                        new String[]{"Baz", "Baz", "Baz", "Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @Test
@@ -524,26 +536,29 @@ public class RingBufferTest
                 "FooBarBazBam-0", "FooBarBazBam-1", "FooBarBazBam-2", "FooBarBazBam-3"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsVarArgIfBatchIsLargerThanRingBuffer() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorVararg<Object[]> translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorVararg<Object[]> translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator,
-                new String[]{"Foo", "Bar", "Baz", "Bam"},
-                new String[]{"Foo", "Bar", "Baz", "Bam"},
-                new String[]{"Foo", "Bar", "Baz", "Bam"},
-                new String[]{"Foo", "Bar", "Baz", "Bam"},
-                new String[]{"Foo", "Bar", "Baz", "Bam"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator,
+                        new String[]{"Foo", "Bar", "Baz", "Bam"},
+                        new String[]{"Foo", "Bar", "Baz", "Bam"},
+                        new String[]{"Foo", "Bar", "Baz", "Bam"},
+                        new String[]{"Foo", "Bar", "Baz", "Bam"},
+                        new String[]{"Foo", "Bar", "Baz", "Bam"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @Test
@@ -586,702 +601,822 @@ public class RingBufferTest
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, 0);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, 0);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, 0);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, 0);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator}, 1, 3);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator}, 1, 3);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator}, 1, 3);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator}, 1, 3);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, -1);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, -1);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, -1);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator, translator}, 1, -1);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
-        try
+        assertThrows(IllegalArgumentException.class, () ->
         {
-            ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator, translator}, -1, 2);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
+            try
+            {
+                ringBuffer.publishEvents(new EventTranslator[]{translator, translator, translator, translator}, -1, 2);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslator<Object[]> translator = new NoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslator<Object[]> translator = new NoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator, translator}, -1, 2);
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(new EventTranslator[]{translator, translator, translator, translator}, -1, 2);
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsOneArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(translator, 1, 0, new String[]{"Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(translator, 1, 0, new String[]{"Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsOneArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, 1, 0, new String[]{"Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, 1, 0, new String[]{"Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsOneArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(translator, 1, 3, new String[]{"Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(translator, 1, 3, new String[]{"Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsOneArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(translator, 1, -1, new String[]{"Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(translator, 1, -1, new String[]{"Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsOneArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
-        try
+        assertThrows(IllegalArgumentException.class, () ->
         {
-            ringBuffer.publishEvents(translator, -1, 2, new String[]{"Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+            try
+            {
+                ringBuffer.publishEvents(translator, -1, 2, new String[]{"Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsOneArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, 1, 3, new String[]{"Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, 1, 3, new String[]{"Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsOneArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            assertFalse(ringBuffer.tryPublishEvents(translator, 1, -1, new String[]{"Foo", "Foo"}));
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                assertFalse(ringBuffer.tryPublishEvents(translator, 1, -1, new String[]{"Foo", "Foo"}));
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsOneArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorOneArg<Object[], String> translator = new OneArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, -1, 2, new String[]{"Foo", "Foo"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, -1, 2, new String[]{"Foo", "Foo"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsTwoArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(translator, 1, 0, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(translator, 1, 0, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsTwoArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, 1, 0, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, 1, 0, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsTwoArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsTwoArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(translator, 1, -1, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(translator, 1, -1, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsTwoArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
-        try
+        assertThrows(IllegalArgumentException.class, () ->
         {
-            ringBuffer.publishEvents(translator, -1, 2, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+            try
+            {
+                ringBuffer.publishEvents(translator, -1, 2, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsTwoArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsTwoArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, 1, -1, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, 1, -1, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsTwoArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorTwoArg<Object[], String, String> translator = new TwoArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(translator, -1, 2, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(translator, -1, 2, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsThreeArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, 1, 0, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
-                new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, 1, 0, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
+                        new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsThreeArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                    translator, 1, 0, new String[]{"Foo", "Foo"},
-                    new String[]{"Bar", "Bar"}, new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, 1, 0, new String[]{"Foo", "Foo"},
+                        new String[]{"Bar", "Bar"}, new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsThreeArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
-                new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
+                        new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsThreeArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, 1, -1, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
-                new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, 1, -1, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
+                        new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsThreeArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, -1, 2, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
-                new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, -1, 2, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
+                        new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsThreeArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
-                new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, 1, 3, new String[]{"Foo", "Foo"}, new String[]{"Bar", "Bar"},
+                        new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsThreeArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator, 1, -1, new String[]{"Foo", "Foo"},
-                new String[]{"Bar", "Bar"}, new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, 1, -1, new String[]{"Foo", "Foo"},
+                        new String[]{"Bar", "Bar"}, new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsThreeArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            EventTranslatorThreeArg<Object[], String, String, String> translator = new ThreeArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator, -1, 2, new String[]{"Foo", "Foo"},
-                new String[]{"Bar", "Bar"}, new String[]{"Baz", "Baz"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, -1, 2, new String[]{"Foo", "Foo"},
+                        new String[]{"Bar", "Bar"}, new String[]{"Baz", "Baz"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsVarArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, 1, 0, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
-                    "Foo2", "Bar2",
-                    "Baz2", "Bam2"
-                });
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, 1, 0, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
+                                "Foo2", "Bar2",
+                                "Baz2", "Bam2"
+                        });
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsVarArgWhenBatchSizeIs0() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                    translator, 1, 0, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                    new String[]{"Foo1", "Bar1", "Baz1", "Bam1"},
-                    new String[]{"Foo2", "Bar2", "Baz2", "Bam2"});
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, 1, 0, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"},
+                        new String[]{"Foo2", "Bar2", "Baz2", "Bam2"});
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsVarArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, 1, 3, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
-                    "Foo2", "Bar2",
-                    "Baz2", "Bam2"
-                });
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, 1, 3, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
+                                "Foo2", "Bar2",
+                                "Baz2", "Bam2"
+                        });
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsVarArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, 1, -1, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
-                    "Foo2", "Bar2",
-                    "Baz2", "Bam2"
-                });
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, 1, -1, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
+                                "Foo2", "Bar2",
+                                "Baz2", "Bam2"
+                        });
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotPublishEventsVarArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.publishEvents(
-                translator, -1, 2, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
-                    "Foo2", "Bar2",
-                    "Baz2", "Bam2"
-                });
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.publishEvents(
+                        translator, -1, 2, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
+                                "Foo2", "Bar2",
+                                "Baz2", "Bam2"
+                        });
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsVarArgWhenBatchExtendsPastEndOfArray() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator, 1, 3, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
-                    "Foo2", "Bar2",
-                    "Baz2", "Bam2"
-                });
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, 1, 3, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
+                                "Foo2", "Bar2",
+                                "Baz2", "Bam2"
+                        });
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsVarArgWhenBatchSizeIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator, 1, -1, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
-                    "Foo2", "Bar2",
-                    "Baz2", "Bam2"
-                });
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, 1, -1, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
+                                "Foo2", "Bar2",
+                                "Baz2", "Bam2"
+                        });
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotTryPublishEventsVarArgWhenBatchStartsAtIsNegative() throws Exception
     {
-        RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
-        VarArgEventTranslator translator = new VarArgEventTranslator();
+        assertThrows(IllegalArgumentException.class, () ->
+        {
+            RingBuffer<Object[]> ringBuffer = RingBuffer.createSingleProducer(new ArrayFactory(1), 4);
+            VarArgEventTranslator translator = new VarArgEventTranslator();
 
-        try
-        {
-            ringBuffer.tryPublishEvents(
-                translator, -1, 2, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
-                new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
-                    "Foo2", "Bar2",
-                    "Baz2", "Bam2"
-                });
-        }
-        finally
-        {
-            assertEmptyRingBuffer(ringBuffer);
-        }
+            try
+            {
+                ringBuffer.tryPublishEvents(
+                        translator, -1, 2, new String[]{"Foo0", "Bar0", "Baz0", "Bam0"},
+                        new String[]{"Foo1", "Bar1", "Baz1", "Bam1"}, new String[]{
+                                "Foo2", "Bar2",
+                                "Baz2", "Bam2"
+                        });
+            }
+            finally
+            {
+                assertEmptyRingBuffer(ringBuffer);
+            }
+        });
     }
 
     @Test

--- a/src/test/java/com/lmax/disruptor/RingBufferWithAssertingStubTest.java
+++ b/src/test/java/com/lmax/disruptor/RingBufferWithAssertingStubTest.java
@@ -1,20 +1,20 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.StubEvent;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class RingBufferWithAssertingStubTest
 {
     private RingBuffer<StubEvent> ringBuffer;
     private Sequencer sequencer;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         sequencer = new AssertingSequencer(16);

--- a/src/test/java/com/lmax/disruptor/SequenceBarrierTest.java
+++ b/src/test/java/com/lmax/disruptor/SequenceBarrierTest.java
@@ -18,14 +18,14 @@ package com.lmax.disruptor;
 import com.lmax.disruptor.support.DummyEventProcessor;
 import com.lmax.disruptor.support.StubEvent;
 import com.lmax.disruptor.util.Util;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.lmax.disruptor.RingBuffer.createMultiProducer;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public final class SequenceBarrierTest
@@ -126,7 +126,7 @@ public final class SequenceBarrierTest
         sequenceBarrier.alert();
         t.join();
 
-        assertTrue("Thread was not interrupted", alerted[0]);
+        assertTrue(alerted[0], "Thread was not interrupted");
     }
 
     @Test

--- a/src/test/java/com/lmax/disruptor/SequenceGroupTest.java
+++ b/src/test/java/com/lmax/disruptor/SequenceGroupTest.java
@@ -15,12 +15,13 @@
  */
 package com.lmax.disruptor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-
-import org.junit.Test;
-
 import com.lmax.disruptor.support.TestEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class SequenceGroupTest
 {

--- a/src/test/java/com/lmax/disruptor/SequenceReportingCallbackTest.java
+++ b/src/test/java/com/lmax/disruptor/SequenceReportingCallbackTest.java
@@ -16,12 +16,12 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.StubEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
 import static com.lmax.disruptor.RingBuffer.createMultiProducer;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SequenceReportingCallbackTest
 {

--- a/src/test/java/com/lmax/disruptor/ShutdownOnFatalExceptionTest.java
+++ b/src/test/java/com/lmax/disruptor/ShutdownOnFatalExceptionTest.java
@@ -3,11 +3,13 @@ package com.lmax.disruptor;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.util.DaemonThreadFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 public class ShutdownOnFatalExceptionTest
 {
@@ -19,7 +21,7 @@ public class ShutdownOnFatalExceptionTest
     private Disruptor<byte[]> disruptor;
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void setUp()
     {
         disruptor = new Disruptor<>(
@@ -29,7 +31,8 @@ public class ShutdownOnFatalExceptionTest
         disruptor.setDefaultExceptionHandler(new FatalExceptionHandler());
     }
 
-    @Test(timeout = 1000)
+    @Test
+    @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
     public void shouldShutdownGracefulEvenWithFatalExceptionHandler()
     {
         disruptor.start();
@@ -43,7 +46,7 @@ public class ShutdownOnFatalExceptionTest
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         disruptor.shutdown();

--- a/src/test/java/com/lmax/disruptor/SingleProducerSequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/SingleProducerSequencerTest.java
@@ -1,9 +1,9 @@
 package com.lmax.disruptor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.*;
 
 public class SingleProducerSequencerTest
 {

--- a/src/test/java/com/lmax/disruptor/SleepingWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/SleepingWaitStrategyTest.java
@@ -15,9 +15,10 @@
  */
 package com.lmax.disruptor;
 
+import org.junit.jupiter.api.Test;
+
 import static com.lmax.disruptor.support.WaitStrategyTestUtil.assertWaitForWithDelayOf;
 
-import org.junit.Test;
 
 public class SleepingWaitStrategyTest
 {

--- a/src/test/java/com/lmax/disruptor/TimeoutBlockingWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/TimeoutBlockingWaitStrategyTest.java
@@ -1,12 +1,13 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.support.DummySequenceBarrier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 
 public class TimeoutBlockingWaitStrategyTest
 {

--- a/src/test/java/com/lmax/disruptor/YieldingWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/YieldingWaitStrategyTest.java
@@ -15,9 +15,9 @@
  */
 package com.lmax.disruptor;
 
-import static com.lmax.disruptor.support.WaitStrategyTestUtil.assertWaitForWithDelayOf;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static com.lmax.disruptor.support.WaitStrategyTestUtil.assertWaitForWithDelayOf;
 
 public class YieldingWaitStrategyTest
 {

--- a/src/test/java/com/lmax/disruptor/dsl/ConsumerRepositoryTest.java
+++ b/src/test/java/com/lmax/disruptor/dsl/ConsumerRepositoryTest.java
@@ -22,11 +22,17 @@ import com.lmax.disruptor.dsl.stubs.SleepingEventHandler;
 import com.lmax.disruptor.support.DummyEventProcessor;
 import com.lmax.disruptor.support.DummySequenceBarrier;
 import com.lmax.disruptor.support.TestEvent;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConsumerRepositoryTest
 {
@@ -38,7 +44,7 @@ public class ConsumerRepositoryTest
     private SequenceBarrier barrier1;
     private SequenceBarrier barrier2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception
     {
         consumerRepository = new ConsumerRepository<>();
@@ -91,10 +97,12 @@ public class ConsumerRepositoryTest
         assertThat(consumerRepository.getEventProcessorFor(handler1), sameInstance(eventProcessor1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenHandlerIsNotRegistered() throws Exception
     {
-        consumerRepository.getEventProcessorFor(new SleepingEventHandler());
+        assertThrows(IllegalArgumentException.class, () ->
+                consumerRepository.getEventProcessorFor(new SleepingEventHandler())
+        );
     }
 
     @Test
@@ -124,7 +132,7 @@ public class ConsumerRepositoryTest
             }
         }
 
-        assertTrue("Included eventProcessor 1", seen1);
-        assertTrue("Included eventProcessor 2", seen2);
+        assertTrue(seen1, "Included eventProcessor 1");
+        assertTrue(seen2, "Included eventProcessor 2");
     }
 }

--- a/src/test/java/com/lmax/disruptor/support/WaitStrategyTestUtil.java
+++ b/src/test/java/com/lmax/disruptor/support/WaitStrategyTestUtil.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class WaitStrategyTestUtil
 {

--- a/src/test/java/com/lmax/disruptor/util/UtilTest.java
+++ b/src/test/java/com/lmax/disruptor/util/UtilTest.java
@@ -16,9 +16,9 @@
 package com.lmax.disruptor.util;
 
 import com.lmax.disruptor.Sequence;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class UtilTest
 {
@@ -27,7 +27,7 @@ public final class UtilTest
     {
         int powerOfTwo = Util.ceilingNextPowerOfTwo(1000);
 
-        Assert.assertEquals(1024, powerOfTwo);
+        assertEquals(1024, powerOfTwo);
     }
 
     @Test
@@ -35,14 +35,14 @@ public final class UtilTest
     {
         int powerOfTwo = Util.ceilingNextPowerOfTwo(1024);
 
-        Assert.assertEquals(1024, powerOfTwo);
+        assertEquals(1024, powerOfTwo);
     }
 
     @Test
     public void shouldReturnMinimumSequence()
     {
         final Sequence[] sequences = {new Sequence(7L), new Sequence(3L), new Sequence(12L)};
-        Assert.assertEquals(3L, Util.getMinimumSequence(sequences));
+        assertEquals(3L, Util.getMinimumSequence(sequences));
     }
 
     @Test
@@ -50,6 +50,6 @@ public final class UtilTest
     {
         final Sequence[] sequences = new Sequence[0];
 
-        Assert.assertEquals(Long.MAX_VALUE, Util.getMinimumSequence(sequences));
+        assertEquals(Long.MAX_VALUE, Util.getMinimumSequence(sequences));
     }
 }


### PR DESCRIPTION
This PR migrates the test codebase to JUnit 5 completely.

Most changes are associated with migrating to `@ParameterizedTest` and `assertThrows` as well as dropping `@Rule` in favour of `AfterEachCallback` in `StubThreadFactory`. This latter requires most attention for reviewers, in my opinion. 

Granularity of commits is fine on purpose. Such granularity, however, is not necessary on the master, so do squash the commits if merging.