### PR TITLE
JCStress test for Sequence

### DIFF
--- a/.github/workflows/jcstress-sanity.yml
+++ b/.github/workflows/jcstress-sanity.yml
@@ -1,0 +1,26 @@
+name: JCStress Testing - commit-level sanity check
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    name: Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew jcstress -Pmode=sanity
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jcstress-report-sanity
+          path: build/reports/jcstress

--- a/.github/workflows/jcstress-stress.yml
+++ b/.github/workflows/jcstress-stress.yml
@@ -3,6 +3,7 @@ name: JCStress Testing - Thorough stress testing
 on:
   schedule:
     - cron: "0 0 * * WED"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/jcstress-weekly-stress.yml
+++ b/.github/workflows/jcstress-weekly-stress.yml
@@ -1,0 +1,28 @@
+name: JCStress Testing - Thorough stress testing
+
+on:
+  schedule:
+    - cron: "0 0 * * WED"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    name: Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew jcstress -Pmode=stress
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jcstress-report-stress
+          path: build/reports/jcstress

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ apply from: 'gradle/maven.gradle'
 apply from: 'gradle/perf.gradle'
 apply from: 'gradle/jmh.gradle'
 apply from: 'gradle/asciidoc.gradle'
+apply from: 'gradle/jcstress.gradle'
 
 wrapper.gradleVersion = '6.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
     id 'signing'
     id 'checkstyle'
     id 'idea'
-
+    id "com.github.erizo.gradle.jcstress" version "0.8.6"
     id 'org.asciidoctor.jvm.convert' version '3.1.0'
 }
 

--- a/gradle/jcstress.gradle
+++ b/gradle/jcstress.gradle
@@ -1,0 +1,3 @@
+jcstress {
+    mode = project.getProperties().getOrDefault("mode", "default")
+}

--- a/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
@@ -6,9 +6,8 @@ import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Outcome;
 import org.openjdk.jcstress.annotations.Ref;
 import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.JJ_Result;
 import org.openjdk.jcstress.infra.results.J_Result;
-import org.openjdk.jcstress.infra.results.LL_Result;
-import org.openjdk.jcstress.infra.results.L_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.*;
 
@@ -38,7 +37,7 @@ public class SequenceStress
         }
 
         @Arbiter
-        public void arbiter(L_Result r)
+        public void arbiter(J_Result r)
         {
             r.r1 = sequence.get();
         }
@@ -68,7 +67,7 @@ public class SequenceStress
         }
 
         @Arbiter
-        public void arbiter(L_Result r)
+        public void arbiter(J_Result r)
         {
             r.r1 = sequence.get();
         }
@@ -99,7 +98,7 @@ public class SequenceStress
         }
 
         @Arbiter
-        public void arbiter(L_Result r)
+        public void arbiter(J_Result r)
         {
             r.r1 = sequence.get();
         }
@@ -216,7 +215,7 @@ public class SequenceStress
         }
 
         @Actor
-        public void actor2(LL_Result r)
+        public void actor2(JJ_Result r)
         {
             Holder h1 = this.h1;
             Holder h2 = this.h2;
@@ -253,7 +252,7 @@ public class SequenceStress
         }
 
         @Actor
-        public void actor2(LL_Result r)
+        public void actor2(JJ_Result r)
         {
             r.r1 = y.get();
             r.r2 = x;
@@ -288,7 +287,7 @@ public class SequenceStress
         }
 
         @Actor
-        public void actor2(LL_Result r)
+        public void actor2(JJ_Result r)
         {
             r.r1 = y.get();
             r.r2 = x;
@@ -309,14 +308,14 @@ public class SequenceStress
         Sequence y = new Sequence(0);
 
         @Actor
-        public void actor1(LL_Result r)
+        public void actor1(JJ_Result r)
         {
             x.setVolatile(1);
             r.r1 = y.get();
         }
 
         @Actor
-        public void actor2(LL_Result r)
+        public void actor2(JJ_Result r)
         {
             y.setVolatile(1);
             r.r2 = x.get();
@@ -337,14 +336,14 @@ public class SequenceStress
         Sequence y = new Sequence(0);
 
         @Actor
-        public void actor1(LL_Result r)
+        public void actor1(JJ_Result r)
         {
             x.set(1);
             r.r1 = y.get();
         }
 
         @Actor
-        public void actor2(LL_Result r)
+        public void actor2(JJ_Result r)
         {
             y.set(1);
             r.r2 = x.get();

--- a/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
@@ -160,6 +160,33 @@ public class SequenceStress
         }
     }
 
+    /**
+     * Updates to non-volatile long values in Java are issued as two separate 32-bit writes.
+     * Sequence should store its underlying value as a volatile long and therefore should not experience this effect.
+     */
+    @JCStressTest
+    @Outcome(id = "0", expect = ACCEPTABLE, desc = "Seeing the default value: writer had not acted yet.")
+    @Outcome(id = "-1", expect = ACCEPTABLE, desc = "Seeing the full value.")
+    @Outcome(expect = FORBIDDEN, desc = "Other cases are forbidden.")
+    @Ref("https://docs.oracle.com/javase/specs/jls/se11/html/jls-17.html#jls-17.7")
+    @State
+    public static class LongFullCompareAndSet
+    {
+        Sequence sequence = new Sequence(0);
+
+        @Actor
+        public void writer()
+        {
+            sequence.compareAndSet(0, 0xFFFFFFFF_FFFFFFFFL);
+        }
+
+        @Actor
+        public void reader(J_Result r)
+        {
+            r.r1 = sequence.get();
+        }
+    }
+
 
     /**
      * In absence of synchronization, the order of independent reads is undefined.

--- a/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
@@ -8,6 +8,7 @@ import org.openjdk.jcstress.annotations.Ref;
 import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.JJ_Result;
 import org.openjdk.jcstress.infra.results.J_Result;
+import org.openjdk.jcstress.infra.results.ZZJ_Result;
 
 import static org.openjdk.jcstress.annotations.Expect.*;
 
@@ -47,29 +48,29 @@ public class SequenceStress
      * `Sequence::compareAndSet` is atomic and should never lose an update, even with multiple threads racing
      */
     @JCStressTest
-    @Outcome(id = "0", expect = FORBIDDEN, desc = "Neither update applied")
-    @Outcome(id = {"10", "20"}, expect = ACCEPTABLE, desc = "Either updated.")
+    @Outcome(id = {"true, false, 10", "false, true, 20"}, expect = ACCEPTABLE, desc = "Either updated.")
+    @Outcome(expect = FORBIDDEN, desc = "Other cases are forbidden.")
     @State
     public static class CompareAndSet
     {
         Sequence sequence = new Sequence(0);
 
         @Actor
-        public void actor1()
+        public void actor1(ZZJ_Result r)
         {
-            sequence.compareAndSet(0, 10);
+            r.r1 = sequence.compareAndSet(0, 10);
         }
 
         @Actor
-        public void actor2()
+        public void actor2(ZZJ_Result r)
         {
-            sequence.compareAndSet(0, 20);
+            r.r2 = sequence.compareAndSet(0, 20);
         }
 
         @Arbiter
-        public void arbiter(J_Result r)
+        public void arbiter(ZZJ_Result r)
         {
-            r.r1 = sequence.get();
+            r.r3 = sequence.get();
         }
     }
 

--- a/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/SequenceStress.java
@@ -1,0 +1,326 @@
+package com.lmax.disruptor;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.Ref;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.J_Result;
+import org.openjdk.jcstress.infra.results.LL_Result;
+import org.openjdk.jcstress.infra.results.L_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public class SequenceStress
+{
+    /**
+     * `Sequence::incrementAndGet` is atomic and should never lose an update, even with multiple threads racing
+     */
+    @JCStressTest
+    @Outcome(id = "1", expect = FORBIDDEN, desc = "One update lost.")
+    @Outcome(id = "2", expect = ACCEPTABLE, desc = "Both updates.")
+    @State
+    public static class IncrementAndGet
+    {
+        Sequence sequence = new Sequence(0);
+
+        @Actor
+        public void actor1()
+        {
+            sequence.incrementAndGet();
+        }
+
+        @Actor
+        public void actor2()
+        {
+            sequence.incrementAndGet();
+        }
+
+        @Arbiter
+        public void arbiter(L_Result r)
+        {
+            r.r1 = sequence.get();
+        }
+    }
+
+    /**
+     * `Sequence::compareAndSet` is atomic and should never lose an update, even with multiple threads racing
+     */
+    @JCStressTest
+    @Outcome(id = "0", expect = FORBIDDEN, desc = "Neither update applied")
+    @Outcome(id = {"10", "20"}, expect = ACCEPTABLE, desc = "Either updated.")
+    @State
+    public static class CompareAndSet
+    {
+        Sequence sequence = new Sequence(0);
+
+        @Actor
+        public void actor1()
+        {
+            sequence.compareAndSet(0, 10);
+        }
+
+        @Actor
+        public void actor2()
+        {
+            sequence.compareAndSet(0, 20);
+        }
+
+        @Arbiter
+        public void arbiter(L_Result r)
+        {
+            r.r1 = sequence.get();
+        }
+    }
+
+    /**
+     * `Sequence::addAndGet` is atomic and should never lose an update, even with multiple threads racing
+     */
+    @JCStressTest
+    @Outcome(id = "10", expect = FORBIDDEN, desc = "One update lost.")
+    @Outcome(id = "20", expect = FORBIDDEN, desc = "One update lost.")
+    @Outcome(id = "30", expect = ACCEPTABLE, desc = "Both updates.")
+    @State
+    public static class AddAndGet
+    {
+        Sequence sequence = new Sequence(0);
+
+        @Actor
+        public void actor1()
+        {
+            sequence.addAndGet(10);
+        }
+
+        @Actor
+        public void actor2()
+        {
+            sequence.addAndGet(20);
+        }
+
+        @Arbiter
+        public void arbiter(L_Result r)
+        {
+            r.r1 = sequence.get();
+        }
+    }
+
+    /**
+     * Updates to non-volatile long values in Java are issued as two separate 32-bit writes.
+     * Sequence should store its underlying value as a volatile long and therefore should not experience this effect
+     * even when a non-volatile UNSAFE set method is used.
+     */
+    @JCStressTest
+    @Outcome(id = "0", expect = ACCEPTABLE, desc = "Seeing the default value: writer had not acted yet.")
+    @Outcome(id = "-1", expect = ACCEPTABLE, desc = "Seeing the full value.")
+    @Outcome(expect = FORBIDDEN, desc = "Other cases are forbidden.")
+    @Ref("https://docs.oracle.com/javase/specs/jls/se11/html/jls-17.html#jls-17.7")
+    @State
+    public static class LongFullSet
+    {
+        Sequence sequence = new Sequence(0);
+
+        @Actor
+        public void writer()
+        {
+            sequence.set(0xFFFFFFFF_FFFFFFFFL);
+        }
+
+        @Actor
+        public void reader(J_Result r)
+        {
+            r.r1 = sequence.get();
+        }
+    }
+
+    /**
+     * Updates to non-volatile long values in Java are issued as two separate 32-bit writes.
+     * Sequence should store its underlying value as a volatile long and therefore should not experience this effect.
+     */
+    @JCStressTest
+    @Outcome(id = "0", expect = ACCEPTABLE, desc = "Seeing the default value: writer had not acted yet.")
+    @Outcome(id = "-1", expect = ACCEPTABLE, desc = "Seeing the full value.")
+    @Outcome(expect = FORBIDDEN, desc = "Other cases are forbidden.")
+    @Ref("https://docs.oracle.com/javase/specs/jls/se11/html/jls-17.html#jls-17.7")
+    @State
+    public static class LongFullSetVolatile
+    {
+        Sequence sequence = new Sequence(0);
+
+        @Actor
+        public void writer()
+        {
+            sequence.setVolatile(0xFFFFFFFF_FFFFFFFFL);
+        }
+
+        @Actor
+        public void reader(J_Result r)
+        {
+            r.r1 = sequence.get();
+        }
+    }
+
+
+    /**
+     * In absence of synchronization, the order of independent reads is undefined.
+     * In our case, the value in Sequence is volatile which mandates the writes to the same
+     * variable to be observed in a total order (that implies that _observers_ are also ordered)
+     */
+    @JCStressTest
+    @Outcome(id = "0, 0", expect = ACCEPTABLE, desc = "Doing both reads early.")
+    @Outcome(id = "1, 1", expect = ACCEPTABLE, desc = "Doing both reads late.")
+    @Outcome(id = "0, 1", expect = ACCEPTABLE, desc = "Doing first read early, not surprising.")
+    @Outcome(id = "1, 0", expect = FORBIDDEN, desc = "Violates coherence.")
+    @State
+    public static class SameVolatileRead
+    {
+        private final Holder h1 = new Holder();
+        private final Holder h2 = h1;
+
+        private static class Holder
+        {
+            Sequence sequence = new Sequence(0);
+        }
+
+        @Actor
+        public void actor1()
+        {
+            h1.sequence.set(1);
+        }
+
+        @Actor
+        public void actor2(LL_Result r)
+        {
+            Holder h1 = this.h1;
+            Holder h2 = this.h2;
+
+            r.r1 = h1.sequence.get();
+            r.r2 = h2.sequence.get();
+        }
+    }
+
+
+    /**
+     * The value field in Sequence is volatile so we should never see an update to it without seeing the update to a
+     * previously set value also.
+     * <p>
+     * If the value was not volatile there would be no ordering rules stopping it being seen updated before the
+     * other value.
+     */
+    @JCStressTest
+    @Outcome(id = "0, 0", expect = ACCEPTABLE, desc = "Doing both reads early.")
+    @Outcome(id = "1, 1", expect = ACCEPTABLE, desc = "Doing both reads late.")
+    @Outcome(id = "0, 1", expect = ACCEPTABLE, desc = "Caught in the middle: $x is visible, $y is not.")
+    @Outcome(id = "1, 0", expect = FORBIDDEN, desc = "Seeing $y, but not $x!")
+    @State
+    public static class SetVolatileGuard
+    {
+        long x = 0;
+        Sequence y = new Sequence(0);
+
+        @Actor
+        public void actor1()
+        {
+            x = 1;
+            y.setVolatile(1);
+        }
+
+        @Actor
+        public void actor2(LL_Result r)
+        {
+            r.r1 = y.get();
+            r.r2 = x;
+        }
+    }
+
+    /**
+     * The value field in Sequence is volatile so we should never see an update to it without seeing the update to a
+     * previously set value also.
+     * <p>
+     * If the value was not volatile there would be no ordering rules stopping it being seen updated before the
+     * other value.
+     * <p>
+     * This is a property of the field, not a property of the method used to set the value of it.
+     */
+    @JCStressTest
+    @Outcome(id = "0, 0", expect = ACCEPTABLE, desc = "Doing both reads early.")
+    @Outcome(id = "1, 1", expect = ACCEPTABLE, desc = "Doing both reads late.")
+    @Outcome(id = "0, 1", expect = ACCEPTABLE, desc = "Caught in the middle: $x is visible, $y is not.")
+    @Outcome(id = "1, 0", expect = FORBIDDEN, desc = "Seeing $y, but not $x!")
+    @State
+    public static class SetGuard
+    {
+        long x = 0;
+        Sequence y = new Sequence(0);
+
+        @Actor
+        public void actor1()
+        {
+            x = 1;
+            y.set(1);
+        }
+
+        @Actor
+        public void actor2(LL_Result r)
+        {
+            r.r1 = y.get();
+            r.r2 = x;
+        }
+    }
+
+
+    /**
+     * Volatile setting will experience total ordering
+     */
+    @JCStressTest
+    @Outcome(id = {"0, 1", "1, 0", "1, 1"}, expect = ACCEPTABLE, desc = "Trivial under sequential consistency")
+    @Outcome(id = "0, 0", expect = FORBIDDEN, desc = "Violates sequential consistency")
+    @State
+    public static class SetVolatileDekker
+    {
+        Sequence x = new Sequence(0);
+        Sequence y = new Sequence(0);
+
+        @Actor
+        public void actor1(LL_Result r)
+        {
+            x.setVolatile(1);
+            r.r1 = y.get();
+        }
+
+        @Actor
+        public void actor2(LL_Result r)
+        {
+            y.setVolatile(1);
+            r.r2 = x.get();
+
+        }
+    }
+
+    /**
+     * Non-volatile setting will not experience total ordering, those gets can be re-ordered and happen before either set
+     */
+    @JCStressTest
+    @Outcome(id = {"0, 1", "1, 0", "1, 1"}, expect = ACCEPTABLE, desc = "Trivial under sequential consistency")
+    @Outcome(id = "0, 0", expect = ACCEPTABLE_INTERESTING, desc = "Violates sequential consistency")
+    @State
+    public static class SetDekker
+    {
+        Sequence x = new Sequence(0);
+        Sequence y = new Sequence(0);
+
+        @Actor
+        public void actor1(LL_Result r)
+        {
+            x.set(1);
+            r.r1 = y.get();
+        }
+
+        @Actor
+        public void actor2(LL_Result r)
+        {
+            y.set(1);
+            r.r2 = x.get();
+        }
+    }
+}


### PR DESCRIPTION
`Sequence` is a very important class to the Disruptor and it has methods like `set` and `setVolatile` which do subtly different things. It also makes general promises for thread safety/atomicity.

Given Sequence has existed for quite some time, this is less of an exercise in testing and more one of documenting existing behaviour.
There are comments on the methods of `Sequence` explaining the Store/Store and Store/Load rules of some of the methods, hopefully this test backs up those comments with some examples.

With this in place the move away from `UNSAFE` to `VarHandle` will be a little more of a proven non-breaking change.