### PR TITLE
Tell Gradle to use the JUnit Platform runner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ compileJava {
     options.warnings = false
 }
 
+test {
+    useJUnitPlatform()
+}
+
 javadoc {
     title = 'Disruptor'
 


### PR DESCRIPTION
Currently, Gradle is attempting to run the `test` suite using the JUnit 4 platform; since everything was recently migrated to JUnit 5, none of the tests are found.

This PR fixes the problem :)