### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
@@ -133,7 +133,7 @@ public final class MultiProducerSequencer extends AbstractSequencer
 
                 if (wrapPoint > gatingSequence)
                 {
-                    LockSupport.parkNanos(1); // TODO, should we spin based on the wait strategy?
+                    LockSupport.parkNanos(1); 
                     continue;
                 }
 


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
src/main/java/com/lmax/disruptor/MultiProducerSequencer.java (line:136)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: 
https://github.com/LMAX-Exchange/disruptor/commit/85905a0f48db8a0997eb1a5c0bf5ec878d399345