### PR TITLE
Change MultiProducerSequencer to use VarHandle instead of Unsafe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'idea'
     id "com.github.erizo.gradle.jcstress" version "0.8.6"
     id 'org.asciidoctor.jvm.convert' version '3.1.0'
+    id 'me.champeau.gradle.jmh' version '0.5.3'
 }
 
 group = 'com.lmax'

--- a/gradle/jmh.gradle
+++ b/gradle/jmh.gradle
@@ -16,31 +16,18 @@ dependencies {
     jmhImplementation 'net.openhft:affinity:3.20.0'
 }
 
-task jmh(type: JavaExec, description: 'Executing JMH benchmarks', group: 'performance') {
-    classpath = sourceSets.jmh.runtimeClasspath
-    main = 'org.openjdk.jmh.Main'
-
-    def profilers = ['pauses']
-    def format = 'json'
-    def resultFile = file("build/reports/jmh/result.${format}")
-    doFirst {
-        resultFile.parentFile.mkdirs()
-    }
-
-    args '-rf', format
-    args '-rff', resultFile
-    args '-foe', 'true' //fail-on-error
-    args '-v', 'NORMAL' //verbosity [SILENT, NORMAL, EXTRA]
-    profilers.each {
-        args '-prof', it
-    }
-    args '-jvmArgsPrepend', '-Xmx256m'
-    args '-jvmArgsPrepend', '-Xms256m'
-    args '-jvmArgsPrepend', '-XX:MaxDirectMemorySize=1g'
+jmh {
+    jmhVersion = '1.26'
+    jvmArgsPrepend =[ '-Xms256m', '-Xmx256m', '-XX:MaxDirectMemorySize=1g' ]
+    resultsFile = project.file("${project.buildDir}/reports/jmh/result.json")
+    profilers = [ 'pauses' ]
+    resultFormat = 'JSON'
+    failOnError = true
+    verbosity = 'NORMAL'
+    includeTests = true
 }
 
-
-task jmhProfilers(type: JavaExec, description:'Lists the available profilers for the jmh task', group: 'performance') {
+task jmhProfilers(type: JavaExec, description:'Lists the available profilers for the jmh task', group: 'jmh') {
     classpath = sourceSets.jmh.runtimeClasspath
     main = 'org.openjdk.jmh.Main'
     args '-lprof'

--- a/src/docs/asciidoc/en/user-guide/20_developing_the_disruptor.adoc
+++ b/src/docs/asciidoc/en/user-guide/20_developing_the_disruptor.adoc
@@ -61,6 +61,38 @@ There are also JMH Benchmarks for testing the performance of the Disruptor, thes
 ----
 $ ./gradlew jmh
 ----
+
+Some JMH Benchmarks can be run on machines with isolated cpus to get results with less error.
+
+Assuming a system set up with isolated cores, e.g.
+
+[source,shell script]
+----
+$ cat /proc/cmdline
+... isolcpus=31,33,35,37,39,41,43,45,47,7,9,11,13,15,17,19,21,23 nohz_full=31,33,35,37,39,41,43,45,47,7,9,11,13,15,17,19,21,23 ...
+----
+
+And the system may have a `cpuset` setup to split application threads from sharing cpus with kernel code:
+
+[source,shell script]
+----
+$ cat /cpusets/app/cpus
+5,7-23,29,31-47
+----
+
+You can run the benchmarks taskset to some of those cpus so that Java threads (like GC and complication) run on some cores
+and JMH Benchmark threads are pinned to isolated cpus using the following command (which is running just the one benchmark, `MultiProducersSequencerBenchmark`):
+
+[source,shell script]
+----
+$ cat runBenchmarks.sh
+#!/bin/bash
+JAVA_HOME=/var/lib/jenkins/workspace/_beant/cache/jdk11/1.11.0.6_zulu11.37.17_ca-1
+ISOLATED_CPUS=7,9,11,13,15,17,19,21,23 $JAVA_HOME/bin/java -jar ./disruptor-4.0.0-SNAPSHOT-jmh.jar -rf json -rff /tmp/jmh-result.json -foe true -v NORMAL -prof perf -jvmArgsPrepend -Xmx256m -jvmArgsPrepend -Xms256m -jvmArgsPrepend -XX:MaxDirectMemorySize=1g $@
+
+$ sudo cset proc -v --exec app -- taskset -c 5,8,10,12,14,16,18,20,22,29,32,34,36,38,40,42,44,46 ./runBenchmarks.sh MultiProducersSequencerBenchmark
+----
+
 --
 
 4. Development tips

--- a/src/jcstress/java/com/lmax/disruptor/MultiProducerSequencerUnsafeStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/MultiProducerSequencerUnsafeStress.java
@@ -1,0 +1,114 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.alternatives.MultiProducerSequencerUnsafe;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.ZZ_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.*;
+
+public final class MultiProducerSequencerUnsafeStress
+{
+    private static Sequencer createSequencer()
+    {
+        return new MultiProducerSequencerUnsafe(64, new BlockingWaitStrategy());
+    }
+
+    @JCStressTest
+    @Outcome(id = {"false, false", "true, false", "true, true"}, expect = ACCEPTABLE, desc = "Assuming ordered updates")
+    @Outcome(id = "false, true", expect = FORBIDDEN, desc = "publish(2) should not be available before publish(1)")
+    @State
+    public static class PublishUpdatesIsAvailableLazily
+    {
+        Sequencer sequencer = createSequencer();
+
+        @Actor
+        public void actor1()
+        {
+            // The store to the underlying availableBuffer is lazily done and stores can be visible out of order
+            sequencer.publish(1);
+            sequencer.publish(2);
+        }
+
+        @Actor
+        public void actor2(ZZ_Result r)
+        {
+            // The load in isAvailable is a full store/load barrier, so any stores from actor1 should get flushed
+            r.r2 = sequencer.isAvailable(2);
+            r.r1 = sequencer.isAvailable(1);
+        }
+    }
+
+    /**
+     * The isAvailable implementation is volatile so we should never see an update to it without seeing the update to a
+     * previously set value also.
+     * <p>
+     * If the value was not volatile there would be no ordering rules stopping it being seen updated before the
+     * other value.
+     */
+    @JCStressTest
+    @Outcome(id = "false, false", expect = ACCEPTABLE, desc = "Doing both reads early.")
+    @Outcome(id = "true, true", expect = ACCEPTABLE, desc = "Doing both reads late.")
+    @Outcome(id = "false, true", expect = ACCEPTABLE, desc = "Caught in the middle: $x is visible, $y is not.")
+    @Outcome(id = "true, false", expect = FORBIDDEN, desc = "Seeing $y, but not $x!")
+    @State
+    public static class GetVolatile
+    {
+        boolean x = false;
+        Sequencer y = createSequencer();
+
+        @Actor
+        public void actor1()
+        {
+            x = true;
+            y.publish(1);
+        }
+
+        @Actor
+        public void actor2(ZZ_Result r)
+        {
+            r.r1 = y.isAvailable(1);
+            r.r2 = x;
+        }
+    }
+
+    /**
+     * In absence of synchronization, the order of independent reads is undefined.
+     * In our case, the read of isAvailable is volatile which mandates the writes to the same
+     * variable to be observed in a total order (that implies that _observers_ are also ordered)
+     */
+    @JCStressTest
+    @Outcome(id = "false, false", expect = ACCEPTABLE, desc = "Doing both reads early.")
+    @Outcome(id = "true, true", expect = ACCEPTABLE, desc = "Doing both reads late.")
+    @Outcome(id = "false, true", expect = ACCEPTABLE, desc = "Doing first read early, not surprising.")
+    @Outcome(id = "true, false", expect = FORBIDDEN, desc = "Violates coherence.")
+    @State
+    public static class SameVolatileRead
+    {
+        private final SameVolatileRead.Holder h1 = new SameVolatileRead.Holder();
+        private final SameVolatileRead.Holder h2 = h1;
+
+        private static class Holder
+        {
+            Sequencer sequence = createSequencer();
+        }
+
+        @Actor
+        public void actor1()
+        {
+            h1.sequence.publish(1);
+        }
+
+        @Actor
+        public void actor2(ZZ_Result r)
+        {
+            SameVolatileRead.Holder h1 = this.h1;
+            SameVolatileRead.Holder h2 = this.h2;
+
+            r.r1 = h1.sequence.isAvailable(1);
+            r.r2 = h2.sequence.isAvailable(1);
+        }
+    }
+}

--- a/src/jcstress/java/com/lmax/disruptor/MultiProducerSequencerVarHandleStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/MultiProducerSequencerVarHandleStress.java
@@ -1,0 +1,113 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.alternatives.MultiProducerSequencerVarHandle;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.ZZ_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+public final class MultiProducerSequencerVarHandleStress
+{
+    private static Sequencer createSequencer()
+    {
+        return new MultiProducerSequencerVarHandle(64, new BlockingWaitStrategy());
+    }
+
+    @JCStressTest
+    @Outcome(id = {"false, false", "true, false", "true, true"}, expect = ACCEPTABLE, desc = "Assuming ordered updates")
+    @Outcome(id = "false, true", expect = FORBIDDEN, desc = "publish(2) should not be available before publish(1)")
+    @State
+    public static class PublishUpdatesIsAvailableLazily
+    {
+        Sequencer sequencer = createSequencer();
+
+        @Actor
+        public void actor1()
+        {
+            sequencer.publish(1);
+            sequencer.publish(2);
+        }
+
+        @Actor
+        public void actor2(ZZ_Result r)
+        {
+            r.r2 = sequencer.isAvailable(2);
+            r.r1 = sequencer.isAvailable(1);
+        }
+    }
+
+    /**
+     * The isAvailable implementation is volatile so we should never see an update to it without seeing the update to a
+     * previously set value also.
+     * <p>
+     * If the value was not volatile there would be no ordering rules stopping it being seen updated before the
+     * other value.
+     */
+    @JCStressTest
+    @Outcome(id = "false, false", expect = ACCEPTABLE, desc = "Doing both reads early.")
+    @Outcome(id = "true, true", expect = ACCEPTABLE, desc = "Doing both reads late.")
+    @Outcome(id = "false, true", expect = ACCEPTABLE, desc = "Caught in the middle: $x is visible, $y is not.")
+    @Outcome(id = "true, false", expect = FORBIDDEN, desc = "Seeing $y, but not $x!")
+    @State
+    public static class GetVolatile
+    {
+        boolean x = false;
+        Sequencer y = createSequencer();
+
+        @Actor
+        public void actor1()
+        {
+            x = true;
+            y.publish(1);
+        }
+
+        @Actor
+        public void actor2(ZZ_Result r)
+        {
+            r.r1 = y.isAvailable(1);
+            r.r2 = x;
+        }
+    }
+
+    /**
+     * In absence of synchronization, the order of independent reads is undefined.
+     * In our case, the read of isAvailable is volatile which mandates the writes to the same
+     * variable to be observed in a total order (that implies that _observers_ are also ordered)
+     */
+    @JCStressTest
+    @Outcome(id = "false, false", expect = ACCEPTABLE, desc = "Doing both reads early.")
+    @Outcome(id = "true, true", expect = ACCEPTABLE, desc = "Doing both reads late.")
+    @Outcome(id = "false, true", expect = ACCEPTABLE, desc = "Doing first read early, not surprising.")
+    @Outcome(id = "true, false", expect = FORBIDDEN, desc = "Violates coherence.")
+    @State
+    public static class SameVolatileRead
+    {
+        private final Holder h1 = new Holder();
+        private final Holder h2 = h1;
+
+        private static class Holder
+        {
+            Sequencer sequence = createSequencer();
+        }
+
+        @Actor
+        public void actor1()
+        {
+            h1.sequence.publish(1);
+        }
+
+        @Actor
+        public void actor2(ZZ_Result r)
+        {
+            Holder h1 = this.h1;
+            Holder h2 = this.h2;
+
+            r.r1 = h1.sequence.isAvailable(1);
+            r.r2 = h2.sequence.isAvailable(1);
+        }
+    }
+}

--- a/src/jmh/java/com/lmax/disruptor/MultiProducerSequencerBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/MultiProducerSequencerBenchmark.java
@@ -1,0 +1,201 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.alternatives.MultiProducerSequencerUnsafe;
+import com.lmax.disruptor.alternatives.MultiProducerSequencerVarHandle;
+import net.openhft.affinity.AffinityLock;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@Threads(1)
+public class MultiProducerSequencerBenchmark
+{
+    // To run this on a tuned system with benchmark threads pinned to isolated cpus:
+    // Run the JMH process with an env var defining the isolated cpu list, e.g. ISOLATED_CPUS=38,40,42,44,46,48 java -jar disruptor-jmh.jar
+    private static final List<Integer> ISOLATED_CPUS = Arrays.stream(System.getenv().getOrDefault("ISOLATED_CPUS", "").split(","))
+            .map(String::trim)
+            .filter(not(String::isBlank))
+            .map(Integer::valueOf)
+            .collect(Collectors.toList());
+
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+
+    @State(Scope.Thread)
+    public static class ThreadPinningState
+    {
+        int threadId = THREAD_COUNTER.getAndIncrement();
+        private AffinityLock affinityLock;
+
+        @Setup
+        public void setup()
+        {
+            if (ISOLATED_CPUS.size() > 0)
+            {
+                if (threadId > ISOLATED_CPUS.size())
+                {
+                    throw new IllegalArgumentException(
+                            String.format("Benchmark uses at least %d threads, only defined %d isolated cpus",
+                                    threadId,
+                                    ISOLATED_CPUS.size()
+                            ));
+                }
+
+                final Integer cpuId = ISOLATED_CPUS.get(threadId);
+                affinityLock = AffinityLock.acquireLock(cpuId);
+                System.out.printf("Attempted to set thread affinity for %s to %d, success = %b%n",
+                        Thread.currentThread().getName(),
+                        cpuId,
+                        affinityLock.isAllocated()
+                );
+            }
+        }
+
+        @TearDown
+        public void teardown()
+        {
+            if (ISOLATED_CPUS.size() > 0)
+            {
+                affinityLock.release();
+            }
+        }
+    }
+
+    /*
+     * com.lmax.disruptor.alternatives.MultiProducerSequencerUnsafe (as of disruptor v3.4.2)
+     */
+    @State(Scope.Group)
+    public static class StateMultiProducerSequencerUnsafe
+    {
+        Sequencer value1 = new MultiProducerSequencerUnsafe(64, new BlockingWaitStrategy());
+        Sequencer value2 = new MultiProducerSequencerUnsafe(64, new BlockingWaitStrategy());
+    }
+
+    @Benchmark
+    @Group("SequenceUnsafe")
+    public boolean read1(final StateMultiProducerSequencerUnsafe s, final ThreadPinningState t)
+    {
+        return s.value1.isAvailable(1);
+    }
+
+    @Benchmark
+    @Group("SequenceUnsafe")
+    public boolean read2(final StateMultiProducerSequencerUnsafe s, final ThreadPinningState t)
+    {
+        return s.value1.isAvailable(1);
+    }
+
+    @Benchmark
+    @Group("SequenceUnsafe")
+    public void setValue1A(final StateMultiProducerSequencerUnsafe s, final ThreadPinningState t)
+    {
+        s.value1.publish(1L);
+    }
+
+    @Benchmark
+    @Group("SequenceUnsafe")
+    public void setValue1B(final StateMultiProducerSequencerUnsafe s, final ThreadPinningState t)
+    {
+        s.value1.publish(2L);
+    }
+
+    @Benchmark
+    @Group("SequenceUnsafe")
+    public void setValue2A(final StateMultiProducerSequencerUnsafe s, final ThreadPinningState t)
+    {
+        s.value2.publish(1L);
+    }
+
+    @Benchmark
+    @Group("SequenceUnsafe")
+    public void setValue2B(final StateMultiProducerSequencerUnsafe s, final ThreadPinningState t)
+    {
+        s.value2.publish(2L);
+    }
+
+    /*
+     * com.lmax.disruptor.alternatives.StateSequenceVarHandle (as of disruptor v3.4.2)
+     */
+    @State(Scope.Group)
+    public static class StateMultiProducerSequencerVarHandle
+    {
+        Sequencer value1 = new MultiProducerSequencerVarHandle(64, new BlockingWaitStrategy());
+        Sequencer value2 = new MultiProducerSequencerVarHandle(64, new BlockingWaitStrategy());
+    }
+
+    @Benchmark
+    @Group("StateMultiProducerSequencerVarHandle")
+    public boolean read1(final StateMultiProducerSequencerVarHandle s, final ThreadPinningState t)
+    {
+        return s.value1.isAvailable(1);
+    }
+
+    @Benchmark
+    @Group("StateMultiProducerSequencerVarHandle")
+    public boolean read2(final StateMultiProducerSequencerVarHandle s, final ThreadPinningState t)
+    {
+        return s.value1.isAvailable(1);
+    }
+
+    @Benchmark
+    @Group("StateMultiProducerSequencerVarHandle")
+    public void setValue1A(final StateMultiProducerSequencerVarHandle s, final ThreadPinningState t)
+    {
+        s.value1.publish(1L);
+    }
+
+    @Benchmark
+    @Group("StateMultiProducerSequencerVarHandle")
+    public void setValue1B(final StateMultiProducerSequencerVarHandle s, final ThreadPinningState t)
+    {
+        s.value1.publish(2L);
+    }
+
+    @Benchmark
+    @Group("StateMultiProducerSequencerVarHandle")
+    public void setValue2A(final StateMultiProducerSequencerVarHandle s, final ThreadPinningState t)
+    {
+        s.value2.publish(1L);
+    }
+
+    @Benchmark
+    @Group("StateMultiProducerSequencerVarHandle")
+    public void setValue2B(final StateMultiProducerSequencerVarHandle s, final ThreadPinningState t)
+    {
+        s.value2.publish(2L);
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(MultiProducerSequencerBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/jmh/java/com/lmax/disruptor/SequenceBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/SequenceBenchmark.java
@@ -24,11 +24,14 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -39,8 +42,12 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SequenceBenchmark
 {
     // To run this on a tuned system with benchmark threads pinned to isolated cpus:
-    // Put a list of cpu ids in the field below, e.g. Arrays.asList(38, 40, 42, 44, 46)
-    private static final List<Integer> ISOLATED_CPUS = Collections.emptyList();
+    // Run the JMH process with an env var defining the isolated cpu list, e.g. ISOLATED_CPUS=38,40,42,44,46,48 java -jar disruptor-jmh.jar
+    private static final List<Integer> ISOLATED_CPUS = Arrays.stream(System.getenv().getOrDefault("ISOLATED_CPUS", "").split(","))
+            .map(String::trim)
+            .filter(not(String::isBlank))
+            .map(Integer::valueOf)
+            .collect(Collectors.toList());
 
     private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
 

--- a/src/test/java/com/lmax/disruptor/alternatives/MultiProducerSequencerUnsafe.java
+++ b/src/test/java/com/lmax/disruptor/alternatives/MultiProducerSequencerUnsafe.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor.alternatives;
+
+import com.lmax.disruptor.AbstractSequencer;
+import com.lmax.disruptor.InsufficientCapacityException;
+import com.lmax.disruptor.Sequence;
+import com.lmax.disruptor.Sequencer;
+import com.lmax.disruptor.WaitStrategy;
+import com.lmax.disruptor.util.Util;
+import sun.misc.Unsafe;
+
+import java.util.concurrent.locks.LockSupport;
+
+
+/**
+ * <p>Coordinator for claiming sequences for access to a data structure while tracking dependent {@link Sequence}s.
+ * Suitable for use for sequencing across multiple publisher threads.</p>
+ *
+ * <p> * Note on {@link Sequencer#getCursor()}:  With this sequencer the cursor value is updated after the call
+ * to {@link Sequencer#next()}, to determine the highest available sequence that can be read, then
+ * {@link Sequencer#getHighestPublishedSequence(long, long)} should be used.</p>
+ */
+public final class MultiProducerSequencerUnsafe extends AbstractSequencer
+{
+    private static final Unsafe UNSAFE = Util.getUnsafe();
+    private static final long BASE = UNSAFE.arrayBaseOffset(int[].class);
+    private static final long SCALE = UNSAFE.arrayIndexScale(int[].class);
+
+    private final Sequence gatingSequenceCache = new Sequence(Sequencer.INITIAL_CURSOR_VALUE);
+
+    // availableBuffer tracks the state of each ringbuffer slot
+    // see below for more details on the approach
+    private final int[] availableBuffer;
+    private final int indexMask;
+    private final int indexShift;
+
+    /**
+     * Construct a Sequencer with the selected wait strategy and buffer size.
+     *
+     * @param bufferSize   the size of the buffer that this will sequence over.
+     * @param waitStrategy for those waiting on sequences.
+     */
+    public MultiProducerSequencerUnsafe(int bufferSize, final WaitStrategy waitStrategy)
+    {
+        super(bufferSize, waitStrategy);
+        availableBuffer = new int[bufferSize];
+        indexMask = bufferSize - 1;
+        indexShift = Util.log2(bufferSize);
+        initialiseAvailableBuffer();
+    }
+
+    /**
+     * @see Sequencer#hasAvailableCapacity(int)
+     */
+    @Override
+    public boolean hasAvailableCapacity(final int requiredCapacity)
+    {
+        return hasAvailableCapacity(gatingSequences, requiredCapacity, cursor.get());
+    }
+
+    private boolean hasAvailableCapacity(Sequence[] gatingSequences, final int requiredCapacity, long cursorValue)
+    {
+        long wrapPoint = (cursorValue + requiredCapacity) - bufferSize;
+        long cachedGatingSequence = gatingSequenceCache.get();
+
+        if (wrapPoint > cachedGatingSequence || cachedGatingSequence > cursorValue)
+        {
+            long minSequence = Util.getMinimumSequence(gatingSequences, cursorValue);
+            gatingSequenceCache.set(minSequence);
+
+            if (wrapPoint > minSequence)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @see Sequencer#claim(long)
+     */
+    @Override
+    public void claim(long sequence)
+    {
+        cursor.set(sequence);
+    }
+
+    /**
+     * @see Sequencer#next()
+     */
+    @Override
+    public long next()
+    {
+        return next(1);
+    }
+
+    /**
+     * @see Sequencer#next(int)
+     */
+    @Override
+    public long next(int n)
+    {
+        if (n < 1 || n > bufferSize)
+        {
+            throw new IllegalArgumentException("n must be > 0 and < bufferSize");
+        }
+
+        long current;
+        long next;
+
+        do
+        {
+            current = cursor.get();
+            next = current + n;
+
+            long wrapPoint = next - bufferSize;
+            long cachedGatingSequence = gatingSequenceCache.get();
+
+            if (wrapPoint > cachedGatingSequence || cachedGatingSequence > current)
+            {
+                long gatingSequence = Util.getMinimumSequence(gatingSequences, current);
+
+                if (wrapPoint > gatingSequence)
+                {
+                    LockSupport.parkNanos(1); // TODO, should we spin based on the wait strategy?
+                    continue;
+                }
+
+                gatingSequenceCache.set(gatingSequence);
+            }
+            else if (cursor.compareAndSet(current, next))
+            {
+                break;
+            }
+        }
+        while (true);
+
+        return next;
+    }
+
+    /**
+     * @see Sequencer#tryNext()
+     */
+    @Override
+    public long tryNext() throws InsufficientCapacityException
+    {
+        return tryNext(1);
+    }
+
+    /**
+     * @see Sequencer#tryNext(int)
+     */
+    @Override
+    public long tryNext(int n) throws InsufficientCapacityException
+    {
+        if (n < 1)
+        {
+            throw new IllegalArgumentException("n must be > 0");
+        }
+
+        long current;
+        long next;
+
+        do
+        {
+            current = cursor.get();
+            next = current + n;
+
+            if (!hasAvailableCapacity(gatingSequences, n, current))
+            {
+                throw InsufficientCapacityException.INSTANCE;
+            }
+        }
+        while (!cursor.compareAndSet(current, next));
+
+        return next;
+    }
+
+    /**
+     * @see Sequencer#remainingCapacity()
+     */
+    @Override
+    public long remainingCapacity()
+    {
+        long consumed = Util.getMinimumSequence(gatingSequences, cursor.get());
+        long produced = cursor.get();
+        return getBufferSize() - (produced - consumed);
+    }
+
+    private void initialiseAvailableBuffer()
+    {
+        for (int i = availableBuffer.length - 1; i != 0; i--)
+        {
+            setAvailableBufferValue(i, -1);
+        }
+
+        setAvailableBufferValue(0, -1);
+    }
+
+    /**
+     * @see Sequencer#publish(long)
+     */
+    @Override
+    public void publish(final long sequence)
+    {
+        setAvailable(sequence);
+        waitStrategy.signalAllWhenBlocking();
+    }
+
+    /**
+     * @see Sequencer#publish(long, long)
+     */
+    @Override
+    public void publish(long lo, long hi)
+    {
+        for (long l = lo; l <= hi; l++)
+        {
+            setAvailable(l);
+        }
+        waitStrategy.signalAllWhenBlocking();
+    }
+
+    /**
+     * The below methods work on the availableBuffer flag.
+     * <p>
+     * The prime reason is to avoid a shared sequence object between publisher threads.
+     * (Keeping single pointers tracking start and end would require coordination
+     * between the threads).
+     * <p>
+     * --  Firstly we have the constraint that the delta between the cursor and minimum
+     * gating sequence will never be larger than the buffer size (the code in
+     * next/tryNext in the Sequence takes care of that).
+     * -- Given that; take the sequence value and mask off the lower portion of the
+     * sequence as the index into the buffer (indexMask). (aka modulo operator)
+     * -- The upper portion of the sequence becomes the value to check for availability.
+     * ie: it tells us how many times around the ring buffer we've been (aka division)
+     * -- Because we can't wrap without the gating sequences moving forward (i.e. the
+     * minimum gating sequence is effectively our last available position in the
+     * buffer), when we have new data and successfully claimed a slot we can simply
+     * write over the top.
+     */
+    private void setAvailable(final long sequence)
+    {
+        setAvailableBufferValue(calculateIndex(sequence), calculateAvailabilityFlag(sequence));
+    }
+
+    private void setAvailableBufferValue(int index, int flag)
+    {
+        long bufferAddress = (index * SCALE) + BASE;
+        UNSAFE.putOrderedInt(availableBuffer, bufferAddress, flag);
+    }
+
+    /**
+     * @see Sequencer#isAvailable(long)
+     */
+    @Override
+    public boolean isAvailable(long sequence)
+    {
+        int index = calculateIndex(sequence);
+        int flag = calculateAvailabilityFlag(sequence);
+        long bufferAddress = (index * SCALE) + BASE;
+        return UNSAFE.getIntVolatile(availableBuffer, bufferAddress) == flag;
+    }
+
+    @Override
+    public long getHighestPublishedSequence(long lowerBound, long availableSequence)
+    {
+        for (long sequence = lowerBound; sequence <= availableSequence; sequence++)
+        {
+            if (!isAvailable(sequence))
+            {
+                return sequence - 1;
+            }
+        }
+
+        return availableSequence;
+    }
+
+    private int calculateAvailabilityFlag(final long sequence)
+    {
+        return (int) (sequence >>> indexShift);
+    }
+
+    private int calculateIndex(final long sequence)
+    {
+        return ((int) sequence) & indexMask;
+    }
+}

--- a/src/test/java/com/lmax/disruptor/alternatives/MultiProducerSequencerVarHandle.java
+++ b/src/test/java/com/lmax/disruptor/alternatives/MultiProducerSequencerVarHandle.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor.alternatives;
+
+import com.lmax.disruptor.AbstractSequencer;
+import com.lmax.disruptor.InsufficientCapacityException;
+import com.lmax.disruptor.Sequence;
+import com.lmax.disruptor.Sequencer;
+import com.lmax.disruptor.WaitStrategy;
+import com.lmax.disruptor.util.Util;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.locks.LockSupport;
+
+
+/**
+ * <p>Coordinator for claiming sequences for access to a data structure while tracking dependent {@link Sequence}s.
+ * Suitable for use for sequencing across multiple publisher threads.</p>
+ *
+ * <p> * Note on {@link Sequencer#getCursor()}:  With this sequencer the cursor value is updated after the call
+ * to {@link Sequencer#next()}, to determine the highest available sequence that can be read, then
+ * {@link Sequencer#getHighestPublishedSequence(long, long)} should be used.</p>
+ */
+public final class MultiProducerSequencerVarHandle extends AbstractSequencer
+{
+    private static final VarHandle AVAILABLE_ARRAY = MethodHandles.arrayElementVarHandle(int[].class);
+
+    private final Sequence gatingSequenceCache = new Sequence(Sequencer.INITIAL_CURSOR_VALUE);
+
+    // availableBuffer tracks the state of each ringbuffer slot
+    // see below for more details on the approach
+    private final int[] availableBuffer;
+    private final int indexMask;
+    private final int indexShift;
+
+    /**
+     * Construct a Sequencer with the selected wait strategy and buffer size.
+     *
+     * @param bufferSize   the size of the buffer that this will sequence over.
+     * @param waitStrategy for those waiting on sequences.
+     */
+    public MultiProducerSequencerVarHandle(int bufferSize, final WaitStrategy waitStrategy)
+    {
+        super(bufferSize, waitStrategy);
+        availableBuffer = new int[bufferSize];
+        indexMask = bufferSize - 1;
+        indexShift = Util.log2(bufferSize);
+        initialiseAvailableBuffer();
+    }
+
+    /**
+     * @see Sequencer#hasAvailableCapacity(int)
+     */
+    @Override
+    public boolean hasAvailableCapacity(final int requiredCapacity)
+    {
+        return hasAvailableCapacity(gatingSequences, requiredCapacity, cursor.get());
+    }
+
+    private boolean hasAvailableCapacity(Sequence[] gatingSequences, final int requiredCapacity, long cursorValue)
+    {
+        long wrapPoint = (cursorValue + requiredCapacity) - bufferSize;
+        long cachedGatingSequence = gatingSequenceCache.get();
+
+        if (wrapPoint > cachedGatingSequence || cachedGatingSequence > cursorValue)
+        {
+            long minSequence = Util.getMinimumSequence(gatingSequences, cursorValue);
+            gatingSequenceCache.set(minSequence);
+
+            if (wrapPoint > minSequence)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @see Sequencer#claim(long)
+     */
+    @Override
+    public void claim(long sequence)
+    {
+        cursor.set(sequence);
+    }
+
+    /**
+     * @see Sequencer#next()
+     */
+    @Override
+    public long next()
+    {
+        return next(1);
+    }
+
+    /**
+     * @see Sequencer#next(int)
+     */
+    @Override
+    public long next(int n)
+    {
+        if (n < 1 || n > bufferSize)
+        {
+            throw new IllegalArgumentException("n must be > 0 and < bufferSize");
+        }
+
+        long current;
+        long next;
+
+        do
+        {
+            current = cursor.get();
+            next = current + n;
+
+            long wrapPoint = next - bufferSize;
+            long cachedGatingSequence = gatingSequenceCache.get();
+
+            if (wrapPoint > cachedGatingSequence || cachedGatingSequence > current)
+            {
+                long gatingSequence = Util.getMinimumSequence(gatingSequences, current);
+
+                if (wrapPoint > gatingSequence)
+                {
+                    LockSupport.parkNanos(1); // TODO, should we spin based on the wait strategy?
+                    continue;
+                }
+
+                gatingSequenceCache.set(gatingSequence);
+            }
+            else if (cursor.compareAndSet(current, next))
+            {
+                break;
+            }
+        }
+        while (true);
+
+        return next;
+    }
+
+    /**
+     * @see Sequencer#tryNext()
+     */
+    @Override
+    public long tryNext() throws InsufficientCapacityException
+    {
+        return tryNext(1);
+    }
+
+    /**
+     * @see Sequencer#tryNext(int)
+     */
+    @Override
+    public long tryNext(int n) throws InsufficientCapacityException
+    {
+        if (n < 1)
+        {
+            throw new IllegalArgumentException("n must be > 0");
+        }
+
+        long current;
+        long next;
+
+        do
+        {
+            current = cursor.get();
+            next = current + n;
+
+            if (!hasAvailableCapacity(gatingSequences, n, current))
+            {
+                throw InsufficientCapacityException.INSTANCE;
+            }
+        }
+        while (!cursor.compareAndSet(current, next));
+
+        return next;
+    }
+
+    /**
+     * @see Sequencer#remainingCapacity()
+     */
+    @Override
+    public long remainingCapacity()
+    {
+        long consumed = Util.getMinimumSequence(gatingSequences, cursor.get());
+        long produced = cursor.get();
+        return getBufferSize() - (produced - consumed);
+    }
+
+    private void initialiseAvailableBuffer()
+    {
+        for (int i = availableBuffer.length - 1; i != 0; i--)
+        {
+            setAvailableBufferValue(i, -1);
+        }
+
+        setAvailableBufferValue(0, -1);
+    }
+
+    /**
+     * @see Sequencer#publish(long)
+     */
+    @Override
+    public void publish(final long sequence)
+    {
+        setAvailable(sequence);
+        waitStrategy.signalAllWhenBlocking();
+    }
+
+    /**
+     * @see Sequencer#publish(long, long)
+     */
+    @Override
+    public void publish(long lo, long hi)
+    {
+        for (long l = lo; l <= hi; l++)
+        {
+            setAvailable(l);
+        }
+        waitStrategy.signalAllWhenBlocking();
+    }
+
+    /**
+     * The below methods work on the availableBuffer flag.
+     * <p>
+     * The prime reason is to avoid a shared sequence object between publisher threads.
+     * (Keeping single pointers tracking start and end would require coordination
+     * between the threads).
+     * <p>
+     * --  Firstly we have the constraint that the delta between the cursor and minimum
+     * gating sequence will never be larger than the buffer size (the code in
+     * next/tryNext in the Sequence takes care of that).
+     * -- Given that; take the sequence value and mask off the lower portion of the
+     * sequence as the index into the buffer (indexMask). (aka modulo operator)
+     * -- The upper portion of the sequence becomes the value to check for availability.
+     * ie: it tells us how many times around the ring buffer we've been (aka division)
+     * -- Because we can't wrap without the gating sequences moving forward (i.e. the
+     * minimum gating sequence is effectively our last available position in the
+     * buffer), when we have new data and successfully claimed a slot we can simply
+     * write over the top.
+     */
+    private void setAvailable(final long sequence)
+    {
+        setAvailableBufferValue(calculateIndex(sequence), calculateAvailabilityFlag(sequence));
+    }
+
+    private void setAvailableBufferValue(int index, int flag)
+    {
+        AVAILABLE_ARRAY.setRelease(availableBuffer, index, flag);
+    }
+
+    /**
+     * @see Sequencer#isAvailable(long)
+     */
+    @Override
+    public boolean isAvailable(long sequence)
+    {
+        int index = calculateIndex(sequence);
+        int flag = calculateAvailabilityFlag(sequence);
+        return (int)AVAILABLE_ARRAY.getAcquire(availableBuffer, index) == flag;
+    }
+
+    @Override
+    public long getHighestPublishedSequence(long lowerBound, long availableSequence)
+    {
+        for (long sequence = lowerBound; sequence <= availableSequence; sequence++)
+        {
+            if (!isAvailable(sequence))
+            {
+                return sequence - 1;
+            }
+        }
+
+        return availableSequence;
+    }
+
+    private int calculateAvailabilityFlag(final long sequence)
+    {
+        return (int) (sequence >>> indexShift);
+    }
+
+    private int calculateIndex(final long sequence)
+    {
+        return ((int) sequence) & indexMask;
+    }
+}


### PR DESCRIPTION
As part of moving towards JDK11 we should be removing uses of sun.misc.Unsafe
MultiProducerSequencer was using Unsafe to provide finer-grained concurrency controls around the availability array which we can replace with the newer VarHandle API.

While adding a JMH benchmark to try and compare the VarHandle version vs Unsafe I also took the opportunity to update the docs on how to run benchmarks on isolated CPUs.
I also changed gradle to use a plugin for JMH which let me build a single jar with all dependencies built in. This made shipping JMH jars to a test system easier when running the benchmarks in isolated mode.

The JCStress tests suggest that all concurrency promises from the unsafe version are still met.
The JMH benchmark results show that the code runs at the same speed, so changes are not overly conservative.

JMH Benchmark result from a tuned system with isolated cpus used to pin benchmark threads:

```
$ cat /proc/cpuinfo | grep 'model name' | uniq
model name	: Intel(R) Xeon(R) CPU E5-2687W v4 @ 3.00GHz

$ <insert tangle of cset, taskset and java>

Benchmark                                                                         Mode  Cnt    Score    Error   Units
MultiProducerSequencerBenchmark.SequenceUnsafe                                   thrpt   10  368.560 ±  9.649  ops/us
MultiProducerSequencerBenchmark.SequenceUnsafe:read1                             thrpt   10  180.491 ±  4.150  ops/us
MultiProducerSequencerBenchmark.SequenceUnsafe:read2                             thrpt   10  178.312 ±  4.981  ops/us
MultiProducerSequencerBenchmark.SequenceUnsafe:setValue1A                        thrpt   10    1.713 ±  0.498  ops/us
MultiProducerSequencerBenchmark.SequenceUnsafe:setValue1B                        thrpt   10    2.436 ±  0.718  ops/us
MultiProducerSequencerBenchmark.SequenceUnsafe:setValue2A                        thrpt   10    1.581 ±  0.662  ops/us
MultiProducerSequencerBenchmark.SequenceUnsafe:setValue2B                        thrpt   10    4.027 ±  0.934  ops/us
MultiProducerSequencerBenchmark.StateMultiProducerSequencerVarHandle             thrpt   10  354.095 ± 20.804  ops/us
MultiProducerSequencerBenchmark.StateMultiProducerSequencerVarHandle:read1       thrpt   10  171.216 ±  9.782  ops/us
MultiProducerSequencerBenchmark.StateMultiProducerSequencerVarHandle:read2       thrpt   10  173.149 ± 11.326  ops/us
MultiProducerSequencerBenchmark.StateMultiProducerSequencerVarHandle:setValue1A  thrpt   10    1.584 ±  0.627  ops/us
MultiProducerSequencerBenchmark.StateMultiProducerSequencerVarHandle:setValue1B  thrpt   10    2.504 ±  0.547  ops/us
MultiProducerSequencerBenchmark.StateMultiProducerSequencerVarHandle:setValue2A  thrpt   10    1.875 ±  0.636  ops/us
MultiProducerSequencerBenchmark.StateMultiProducerSequencerVarHandle:setValue2B  thrpt   10    3.766 ±  0.854  ops/us
```