### PR TITLE
Increase MultiProducerSequencer performance on getting next sequence

### DIFF
--- a/src/main/java/com/lmax/disruptor/Sequence.java
+++ b/src/main/java/com/lmax/disruptor/Sequence.java
@@ -103,6 +103,17 @@ public class Sequence extends RhsPadding
     }
 
     /**
+     * Perform an atomic getAndAdd operation on the sequence.
+     *
+     * @param increment The value to add to the sequence.
+     * @return the value before increment
+     */
+    public long getAndAdd(final long increment)
+    {
+        return UNSAFE.getAndAddLong(this, VALUE_OFFSET, increment);
+    }
+
+    /**
      * Performs a volatile write of this sequence.  The intent is
      * a Store/Store barrier between this write and any previous
      * write and a Store/Load barrier between this write and any

--- a/src/test/java/com/lmax/disruptor/RingBufferTest.java
+++ b/src/test/java/com/lmax/disruptor/RingBufferTest.java
@@ -190,7 +190,8 @@ public class RingBufferTest
         thread.start();
 
         latch.await();
-        assertThat(Long.valueOf(buffer2.getCursor()), is(Long.valueOf(ringBufferSize - 1)));
+        assertThat(Long.valueOf(buffer2.getCursor()), is(Long.valueOf(ringBufferSize)));
+        assertFalse(buffer2.isPublished(buffer2.getCursor()));
         assertFalse(publisherComplete.get());
 
         processor.run();

--- a/src/test/java/com/lmax/disruptor/SequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/SequencerTest.java
@@ -93,7 +93,9 @@ public class SequencerTest
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
         final long expectedFullSequence = Sequencer.INITIAL_CURSOR_VALUE + sequencer.getBufferSize();
-        assertThat(sequencer.getCursor(), is(expectedFullSequence));
+        assertThat(
+            sequencer.getHighestPublishedSequence(Sequencer.INITIAL_CURSOR_VALUE + 1, sequencer.getCursor()),
+            is(expectedFullSequence));
 
         executor.submit(
             new Runnable()
@@ -111,12 +113,14 @@ public class SequencerTest
             });
 
         waitingLatch.await();
-        assertThat(sequencer.getCursor(), is(expectedFullSequence));
+        assertThat(
+            sequencer.getHighestPublishedSequence(expectedFullSequence, sequencer.getCursor()),
+            is(expectedFullSequence));
 
         gatingSequence.set(Sequencer.INITIAL_CURSOR_VALUE + 1L);
 
         doneLatch.await();
-        assertThat(sequencer.getCursor(), is(expectedFullSequence + 1L));
+        assertThat(sequencer.getHighestPublishedSequence(expectedFullSequence, sequencer.getCursor()), is(expectedFullSequence + 1L));
     }
 
     @Test(expected = InsufficientCapacityException.class)


### PR DESCRIPTION
The MultiProducerSequencer currently has contention problems when many threads try to get the next sequence. It is not necessary to loop trying to compareAndSet the new sequence number. The producer can allocate sequence numbers upfront as long as it does not return when the consumer has not consumed the slot yet. The up-front allocation is valid because the call to getHighestPublisedSequence is the one that will tell the consumer that a slot has been published by the publisher.