### PR TITLE
Increase MultiProducerSequencer performance on getting next sequence (master branch)

### DIFF
--- a/src/jmh/java/com/lmax/disruptor/MultiProducerSingleConsumer.java
+++ b/src/jmh/java/com/lmax/disruptor/MultiProducerSingleConsumer.java
@@ -1,0 +1,74 @@
+package com.lmax.disruptor;
+
+import java.util.concurrent.TimeUnit;
+
+import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.DaemonThreadFactory;
+import com.lmax.disruptor.util.SimpleEvent;
+import com.lmax.disruptor.util.SimpleEventHandler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+public class MultiProducerSingleConsumer
+{
+    private RingBuffer<SimpleEvent> ringBuffer;
+    private Disruptor<SimpleEvent> disruptor;
+    private static final int BIG_BUFFER = 1 << 22;
+
+    @Setup
+    public void setup(final Blackhole bh)
+    {
+        disruptor = new Disruptor<>(SimpleEvent::new,
+                BIG_BUFFER,
+                DaemonThreadFactory.INSTANCE,
+                ProducerType.MULTI,
+                new BusySpinWaitStrategy());
+
+        disruptor.handleEventsWith(new SimpleEventHandler(bh));
+
+        ringBuffer = disruptor.start();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public void producing()
+    {
+        long sequence = ringBuffer.next();
+        SimpleEvent simpleEvent = ringBuffer.get(sequence);
+        simpleEvent.setValue(0);
+        ringBuffer.publish(sequence);
+    }
+
+    @TearDown
+    public void tearDown()
+    {
+        disruptor.shutdown();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(MultiProducerSingleConsumer.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
@@ -116,37 +116,24 @@ public final class MultiProducerSequencer extends AbstractSequencer
             throw new IllegalArgumentException("n must be > 0 and < bufferSize");
         }
 
-        long current;
-        long next;
+        long current = cursor.getAndAdd(n);
 
-        do
+        long nextSequence = current + n;
+        long wrapPoint = nextSequence - bufferSize;
+        long cachedGatingSequence = gatingSequenceCache.get();
+
+        if (wrapPoint > cachedGatingSequence || cachedGatingSequence > current)
         {
-            current = cursor.get();
-            next = current + n;
-
-            long wrapPoint = next - bufferSize;
-            long cachedGatingSequence = gatingSequenceCache.get();
-
-            if (wrapPoint > cachedGatingSequence || cachedGatingSequence > current)
+            long gatingSequence;
+            while (wrapPoint > (gatingSequence = Util.getMinimumSequence(gatingSequences, current)))
             {
-                long gatingSequence = Util.getMinimumSequence(gatingSequences, current);
-
-                if (wrapPoint > gatingSequence)
-                {
-                    LockSupport.parkNanos(1); // TODO, should we spin based on the wait strategy?
-                    continue;
-                }
-
-                gatingSequenceCache.set(gatingSequence);
+                LockSupport.parkNanos(1L); // TODO, should we spin based on the wait strategy?
             }
-            else if (cursor.compareAndSet(current, next))
-            {
-                break;
-            }
+
+            gatingSequenceCache.set(gatingSequence);
         }
-        while (true);
 
-        return next;
+        return nextSequence;
     }
 
     /**

--- a/src/main/java/com/lmax/disruptor/Sequence.java
+++ b/src/main/java/com/lmax/disruptor/Sequence.java
@@ -111,7 +111,7 @@ public class Sequence extends RhsPadding
      */
     public long getAndAdd(final long increment)
     {
-        return UNSAFE.getAndAddLong(this, VALUE_OFFSET, increment);
+        return (long) VALUE_FIELD.getAndAdd(this, increment);
     }
 
     /**

--- a/src/main/java/com/lmax/disruptor/Sequence.java
+++ b/src/main/java/com/lmax/disruptor/Sequence.java
@@ -104,6 +104,17 @@ public class Sequence extends RhsPadding
     }
 
     /**
+     * Perform an atomic getAndAdd operation on the sequence.
+     *
+     * @param increment The value to add to the sequence.
+     * @return the value before increment
+     */
+    public long getAndAdd(final long increment)
+    {
+        return UNSAFE.getAndAddLong(this, VALUE_OFFSET, increment);
+    }
+
+    /**
      * Performs a volatile write of this sequence.  The intent is
      * a Store/Store barrier between this write and any previous
      * write and a Store/Load barrier between this write and any

--- a/src/test/java/com/lmax/disruptor/RingBufferTest.java
+++ b/src/test/java/com/lmax/disruptor/RingBufferTest.java
@@ -186,7 +186,8 @@ public class RingBufferTest
         thread.start();
 
         latch.await();
-        assertThat(Long.valueOf(buffer2.getCursor()), is(Long.valueOf(ringBufferSize - 1)));
+        assertThat(Long.valueOf(buffer2.getCursor()), is(Long.valueOf(ringBufferSize)));
+        assertFalse(buffer2.isPublished(buffer2.getCursor()));
         assertFalse(publisherComplete.get());
 
         processor.run();

--- a/src/test/java/com/lmax/disruptor/SequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/SequencerTest.java
@@ -107,7 +107,9 @@ public class SequencerTest
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
         final long expectedFullSequence = Sequencer.INITIAL_CURSOR_VALUE + sequencer.getBufferSize();
-        assertThat(sequencer.getCursor(), is(expectedFullSequence));
+        assertThat(
+            sequencer.getHighestPublishedSequence(Sequencer.INITIAL_CURSOR_VALUE + 1, sequencer.getCursor()),
+            is(expectedFullSequence));
 
         executor.submit(
                 () ->
@@ -121,12 +123,14 @@ public class SequencerTest
                 });
 
         waitingLatch.await();
-        assertThat(sequencer.getCursor(), is(expectedFullSequence));
+        assertThat(
+            sequencer.getHighestPublishedSequence(expectedFullSequence, sequencer.getCursor()),
+            is(expectedFullSequence));
 
         gatingSequence.set(Sequencer.INITIAL_CURSOR_VALUE + 1L);
 
         doneLatch.await();
-        assertThat(sequencer.getCursor(), is(expectedFullSequence + 1L));
+        assertThat(sequencer.getHighestPublishedSequence(expectedFullSequence, sequencer.getCursor()), is(expectedFullSequence + 1L));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
The MultiProducerSequencer currently has contention problems when many threads try to get the next sequence. It is not necessary to loop trying to compareAndSet the new sequence number. The producer can allocate sequence numbers upfront as long as it does not return when the consumer has not consumed the slot yet. The up-front allocation is valid because the call to getHighestPublisedSequence is the one that will tell the consumer that a slot has been published by the publisher.

Note: this pull request was first issued as #355 (on the older version). This new pull request is based off the master branch. I've also added the MultiProducerSingleConsumer jmh benchmark test.