### PR TITLE
Changed expected exception check by JUnit API usage

### DIFF
--- a/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
@@ -31,7 +31,8 @@ public final class FatalExceptionHandlerTest
 
         ExceptionHandler<Object> exceptionHandler = new FatalExceptionHandler();
 
-        Throwable ex =  assertThrows(RuntimeException.class,() -> {
+        Throwable ex =  assertThrows(RuntimeException.class, () ->
+        {
             exceptionHandler.handleEventException(causeException, 0L, event);
         });
 

--- a/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
+++ b/src/test/java/com/lmax/disruptor/FatalExceptionHandlerTest.java
@@ -19,6 +19,7 @@ import com.lmax.disruptor.support.TestEvent;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class FatalExceptionHandlerTest
 {
@@ -30,13 +31,10 @@ public final class FatalExceptionHandlerTest
 
         ExceptionHandler<Object> exceptionHandler = new FatalExceptionHandler();
 
-        try
-        {
+        Throwable ex =  assertThrows(RuntimeException.class,() -> {
             exceptionHandler.handleEventException(causeException, 0L, event);
-        }
-        catch (RuntimeException ex)
-        {
-            assertEquals(causeException, ex.getCause());
-        }
+        });
+
+        assertEquals(causeException, ex.getCause());
     }
 }


### PR DESCRIPTION
**Problem:**
The idea of this refactoring proposal is to make the exception catching a responsibility of the test framework, which is already provided by its API. Also, without the need of using try/catch blocks, tests can be more straightforward and possibly more comprehensible.

**Solution:**
We propose using JUnit's exception handling to automatically pass/fail the test instead of writing custom exception handling code. In this particular case, JUnit 5 assertThrows() was used to properly handle the expected exception.

**Result:**
_Before:_
```
try
{
    exceptionHandler.handleEventException(causeException, 0L, event);
}
catch (RuntimeException ex)
{
    assertEquals(causeException, ex.getCause());
}
```

_After:_
```
Throwable ex =  assertThrows(RuntimeException.class,() -> {
    exceptionHandler.handleEventException(causeException, 0L, event);
});

assertEquals(causeException, ex.getCause());
```