### PR TITLE
Use platform logging API in FatalExceptionHandler and IgnoreExceptionHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Issue #323 - `WorkerPool` and `WorkProcessor` have been removed, no more `Disruptor::handleEventsWithWorkerPool`
     - Deprecated ThreadHints.onSpinWait()
     - `Disruptor` constructors using Executor have been removed. Use ThreadFactory instead.
+    - FatalExceptionHandler and IgnoreExceptionHandler now use the JDK 9 Platform Logging API, i.e. System.Logger
 
 ## 3.4.2
 

--- a/src/main/java/com/lmax/disruptor/FatalExceptionHandler.java
+++ b/src/main/java/com/lmax/disruptor/FatalExceptionHandler.java
@@ -15,32 +15,22 @@
  */
 package com.lmax.disruptor;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger.Level;
+import java.lang.System.Logger;
 
 /**
- * Convenience implementation of an exception handler that using standard JDK logging to log
- * the exception as {@link Level}.SEVERE and re-throw it wrapped in a {@link RuntimeException}
+ * Convenience implementation of an exception handler that uses the standard JDK logging
+ * of {@link System.Logger} to log the exception as {@link Level}.ERROR and re-throw
+ * it wrapped in a {@link RuntimeException}
  */
 public final class FatalExceptionHandler implements ExceptionHandler<Object>
 {
-    private static final Logger LOGGER = Logger.getLogger(FatalExceptionHandler.class.getName());
-    private final Logger logger;
-
-    public FatalExceptionHandler()
-    {
-        this.logger = LOGGER;
-    }
-
-    public FatalExceptionHandler(final Logger logger)
-    {
-        this.logger = logger;
-    }
+    private static final Logger LOGGER = System.getLogger(FatalExceptionHandler.class.getName());
 
     @Override
     public void handleEventException(final Throwable ex, final long sequence, final Object event)
     {
-        logger.log(Level.SEVERE, "Exception processing: " + sequence + " " + event, ex);
+        LOGGER.log(Level.ERROR, "Exception processing: " + sequence + " " + event, ex);
 
         throw new RuntimeException(ex);
     }
@@ -48,12 +38,12 @@ public final class FatalExceptionHandler implements ExceptionHandler<Object>
     @Override
     public void handleOnStartException(final Throwable ex)
     {
-        logger.log(Level.SEVERE, "Exception during onStart()", ex);
+        LOGGER.log(Level.ERROR, "Exception during onStart()", ex);
     }
 
     @Override
     public void handleOnShutdownException(final Throwable ex)
     {
-        logger.log(Level.SEVERE, "Exception during onShutdown()", ex);
+        LOGGER.log(Level.ERROR, "Exception during onShutdown()", ex);
     }
 }

--- a/src/main/java/com/lmax/disruptor/FatalExceptionHandler.java
+++ b/src/main/java/com/lmax/disruptor/FatalExceptionHandler.java
@@ -30,7 +30,7 @@ public final class FatalExceptionHandler implements ExceptionHandler<Object>
     @Override
     public void handleEventException(final Throwable ex, final long sequence, final Object event)
     {
-        LOGGER.log(Level.ERROR, "Exception processing: " + sequence + " " + event, ex);
+        LOGGER.log(Level.ERROR, () -> "Exception processing: " + sequence + " " + event, ex);
 
         throw new RuntimeException(ex);
     }

--- a/src/main/java/com/lmax/disruptor/IgnoreExceptionHandler.java
+++ b/src/main/java/com/lmax/disruptor/IgnoreExceptionHandler.java
@@ -15,43 +15,32 @@
  */
 package com.lmax.disruptor;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger.Level;
+import java.lang.System.Logger;
 
 /**
- * Convenience implementation of an exception handler that using standard JDK logging to log
- * the exception as {@link Level}.INFO
+ * Convenience implementation of an exception handler that uses the standard JDK logging
+ * of {@link System.Logger} to log the exception as {@link Level}.INFO
  */
 public final class IgnoreExceptionHandler implements ExceptionHandler<Object>
 {
-    private static final Logger LOGGER = Logger.getLogger(IgnoreExceptionHandler.class.getName());
-    private final Logger logger;
-
-    public IgnoreExceptionHandler()
-    {
-        this.logger = LOGGER;
-    }
-
-    public IgnoreExceptionHandler(final Logger logger)
-    {
-        this.logger = logger;
-    }
+    private static final Logger LOGGER = System.getLogger(IgnoreExceptionHandler.class.getName());
 
     @Override
     public void handleEventException(final Throwable ex, final long sequence, final Object event)
     {
-        logger.log(Level.INFO, "Exception processing: " + sequence + " " + event, ex);
+        LOGGER.log(Level.INFO, "Exception processing: " + sequence + " " + event, ex);
     }
 
     @Override
     public void handleOnStartException(final Throwable ex)
     {
-        logger.log(Level.INFO, "Exception during onStart()", ex);
+        LOGGER.log(Level.INFO, "Exception during onStart()", ex);
     }
 
     @Override
     public void handleOnShutdownException(final Throwable ex)
     {
-        logger.log(Level.INFO, "Exception during onShutdown()", ex);
+        LOGGER.log(Level.INFO, "Exception during onShutdown()", ex);
     }
 }

--- a/src/main/java/com/lmax/disruptor/IgnoreExceptionHandler.java
+++ b/src/main/java/com/lmax/disruptor/IgnoreExceptionHandler.java
@@ -29,7 +29,7 @@ public final class IgnoreExceptionHandler implements ExceptionHandler<Object>
     @Override
     public void handleEventException(final Throwable ex, final long sequence, final Object event)
     {
-        LOGGER.log(Level.INFO, "Exception processing: " + sequence + " " + event, ex);
+        LOGGER.log(Level.INFO, () -> "Exception processing: " + sequence + " " + event, ex);
     }
 
     @Override


### PR DESCRIPTION
Changing from java.util.logging to the [Platform Logging API](https://openjdk.java.net/jeps/264) is preferable now that this library is targeting JDK 11.

* Removes the dependency on java.util.logging, which some modular applications may want to avoid.
* Both java.util.logging and System.Logger can be redirected to a logging framework of choice. However, doing so is far more clean, straightforward, and effective for System.Logger. (I would wager performant too, given jul's creation of LogRecord objects)
* By default, the System.Logger API routes to java.util.logging, so for the majority of users this will be a non-breaking change and the behavior will be exactly the same. It is listed as a breaking change because:
  * FatalExceptionHandler's constructor taking a Logger has been removed.
  * It affects the highly unlikely setup where the user has implemented the system logging API to use a certain logging framework but has not done the same for java.util.logging.
* This may coincidentally solve some initialization cycles in Log4j between log4j-core and log4j-jul, see https://github.com/apache/logging-log4j2/pull/447 . That is not the main benefit of this change however.

