### PR TITLE
Fix #370: Logger instances are lazily initialized

### DIFF
--- a/src/jcstress/java/com/lmax/disruptor/LoggerInitializationStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/LoggerInitializationStress.java
@@ -1,0 +1,150 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.Util;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Mode;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.Signal;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Executors;
+import java.util.logging.LogManager;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+/**
+ * Validate that creating a {@link Disruptor} instance with a custom {@link ExceptionHandler} does not
+ * initialize the logging framework. Using JCStress is a stretch, we're not validating a race condition,
+ * rather that the logging framework is not started. This type of test doesn't work well in unit tests
+ * because it requires JVM isolation, and any interactions with a logger invalidate the test.
+ */
+@JCStressTest(Mode.Termination)
+@Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Logger has not been initialized")
+@Outcome(
+        id = {"STALE", "ERROR"},
+        expect = FORBIDDEN,
+        desc = "Logger has been initialized. This has the potential to cause " +
+                "deadlocks when disruptor is used within logging frameworks")
+public class LoggerInitializationStress
+{
+    private static volatile boolean logManagerInitialized;
+    private static volatile boolean disruptorInitialized;
+    static
+    {
+        System.setProperty("java.util.logging.manager", DisruptorLogManager.class.getCanonicalName());
+    }
+
+    @Actor
+    public void actor() throws Exception
+    {
+        // Wait for a the Disruptor instance to be initialized
+        while (!disruptorInitialized)
+        {
+        }
+        // Validate state
+        if (logManagerInitialized)
+        {
+            throw new RuntimeException("Expected the LogManager to be uninitialized");
+        }
+        // Use Unsafe to determine if the LogManager has been initialized.
+        // Accessing the LogManager normally using LogManager.getLogManager
+        // results in initialization which modifies static state and prevents
+        // subsequent runs from executing successfully.
+        Field managerField = LogManager.class.getDeclaredField("manager");
+        Unsafe unsafe = Util.getUnsafe();
+        Object managerBase = unsafe.staticFieldBase(managerField);
+        long managerOffset = unsafe.staticFieldOffset(managerField);
+        Object logManager = unsafe.getObject(managerBase, managerOffset);
+        if (logManager != null)
+        {
+            throw new RuntimeException("Unexpected LogManager: " + logManager);
+        }
+    }
+
+    @Signal
+    public void signal()
+    {
+        final Disruptor disruptor = new Disruptor<>(
+                SimpleEvent::new,
+                128,
+                Executors.defaultThreadFactory(),
+                ProducerType.MULTI,
+                new BlockingWaitStrategy());
+        disruptor.setDefaultExceptionHandler(SimpleEventExceptionHandler.INSTANCE);
+        disruptor.handleEventsWith(SimpleEventHandler.INSTANCE);
+        disruptor.start();
+        disruptor.halt();
+        disruptorInitialized = true;
+    }
+
+    public static final class DisruptorLogManager extends LogManager
+    {
+        static
+        {
+            logManagerInitialized = true;
+        }
+    }
+
+    public static final class SimpleEvent
+    {
+        private long value = Long.MIN_VALUE;
+
+        public long getValue()
+        {
+            return value;
+        }
+
+        public void setValue(final long value)
+        {
+            this.value = value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "SimpleEvent{" +
+                    "value=" + value +
+                    '}';
+        }
+    }
+
+    public enum SimpleEventHandler implements EventHandler<SimpleEvent>
+    {
+        INSTANCE;
+
+        @Override
+        public void onEvent(final SimpleEvent event, final long sequence, final boolean endOfBatch)
+        {
+            // nop
+        }
+    }
+
+    public enum SimpleEventExceptionHandler implements ExceptionHandler<SimpleEvent>
+    {
+        INSTANCE;
+
+        @Override
+        public void handleEventException(final Throwable ex, final long sequence, final SimpleEvent event)
+        {
+            // nop
+        }
+
+        @Override
+        public void handleOnStartException(final Throwable ex)
+        {
+            // nop
+        }
+
+        @Override
+        public void handleOnShutdownException(final Throwable ex)
+        {
+            // nop
+        }
+    }
+
+}

--- a/src/main/java/com/lmax/disruptor/ExceptionHandlers.java
+++ b/src/main/java/com/lmax/disruptor/ExceptionHandlers.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor;
+
+/** Provides static methods for accessing a default {@link ExceptionHandler} object. */
+public final class ExceptionHandlers
+{
+
+    /**
+     * Get a reference to the default {@link ExceptionHandler} instance.
+     *
+     * @return a reference to the default {@link ExceptionHandler} instance
+     */
+    public static ExceptionHandler<Object> defaultHandler()
+    {
+        return DefaultExceptionHandlerHolder.HANDLER;
+    }
+
+    private ExceptionHandlers()
+    {
+    }
+
+    // lazily initialize the default exception handler.
+    // This nested object isn't strictly necessary unless additional utility functionality is
+    // added to ExceptionHandlers, but it exists to ensure the code remains obvious.
+    private static final class DefaultExceptionHandlerHolder
+    {
+        private static final ExceptionHandler<Object> HANDLER = new FatalExceptionHandler();
+    }
+}

--- a/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
@@ -1,11 +1,11 @@
 package com.lmax.disruptor.dsl;
 
 import com.lmax.disruptor.ExceptionHandler;
-import com.lmax.disruptor.FatalExceptionHandler;
+import com.lmax.disruptor.ExceptionHandlers;
 
 public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
 {
-    private ExceptionHandler<? super T> delegate = new FatalExceptionHandler();
+    private ExceptionHandler<? super T> delegate;
 
     public void switchTo(final ExceptionHandler<? super T> exceptionHandler)
     {
@@ -15,18 +15,24 @@ public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
     @Override
     public void handleEventException(final Throwable ex, final long sequence, final T event)
     {
-        delegate.handleEventException(ex, sequence, event);
+        getExceptionHandler().handleEventException(ex, sequence, event);
     }
 
     @Override
     public void handleOnStartException(final Throwable ex)
     {
-        delegate.handleOnStartException(ex);
+        getExceptionHandler().handleOnStartException(ex);
     }
 
     @Override
     public void handleOnShutdownException(final Throwable ex)
     {
-        delegate.handleOnShutdownException(ex);
+        getExceptionHandler() .handleOnShutdownException(ex);
+    }
+
+    private ExceptionHandler<? super T> getExceptionHandler()
+    {
+        ExceptionHandler<? super T> handler = delegate;
+        return handler == null ? ExceptionHandlers.defaultHandler() : handler;
     }
 }


### PR DESCRIPTION
Default java loggers are no longer initialized when custom
ExceptionHandler instances are provided. This allows logging
frameworks to delegate to disruptor without risking deadlocks.

Implementation notes:

This introduces a new public utility class `ExceptionHandlers` which exposes a singleton `ExceptionHandler<Object>` that can be lazily initialized. This allows the handler to be centrally controlled and shared between `BatchEventProcessor` and `ExceptionHandlerWrapper`.

The `ExceptionHandler` instances are stored in non-volatile fields, so I opted to null check and produce the default singleton instead of attempting to initialize the field to some default just prior to initialization. This way even unexpected concurrent initial accesses should not be able to produce different behavior if this patch is applied.

`BatchEventProcessor` is performance sensitive, so I opted to structure changes in such a way that method size will not grow, in case it's optimized by size for inlining. Exception handling generally occurs out of hot paths, so additional method call overhead should be negligible, and the calling method size should be slightly lower, avoiding the `exceptionHandler` object lookup bytecode. As an aside, the `BatchEventProcessor` hot loop may benefit from a single final field read outside of the loop to avoid unnecessary indirection because `-XX:+TrustFinalNonStaticFields` still isn't the default JVM behavior.