### PR TITLE
GHA: Perform "quick" jcstress run instead of "sanity"

### DIFF
--- a/.github/workflows/jcstress-quick.yml
+++ b/.github/workflows/jcstress-quick.yml
@@ -1,4 +1,4 @@
-name: JCStress Testing - commit-level sanity check
+name: JCStress Testing - commit-level quick check
 
 on: [ push, pull_request ]
 
@@ -18,9 +18,9 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew jcstress -Pmode=sanity
+        run: ./gradlew jcstress -Pmode=quick
       - name: Archive artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: jcstress-report-sanity
+          name: jcstress-report-quick
           path: build/reports/jcstress


### PR DESCRIPTION
I noticed that GHA workflow runs jcstress "sanity" mode as the commit-level check. "sanity" mode is really for jcstress infrastructure testing, as it spends almost no time in the tests themselves. If we want to run the fast testing that spend some time in test code, we are better off doing "quick" runs.

Downside: it takes about 7 minutes to run. This can be made better to culling the number of JVM configuration the tests run.