### PR TITLE
JCStress test to validate that loggers aren't initialized

### DIFF
--- a/src/jcstress/java/com/lmax/disruptor/LoggerInitializationStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/LoggerInitializationStress.java
@@ -1,0 +1,144 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.Util;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Mode;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.Signal;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Executors;
+import java.util.logging.LogManager;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+/**
+ * Validate that creating a {@link Disruptor} instance with a custom {@link ExceptionHandler} does not
+ * initialize the logging framework. Using JCStress is a stretch, we're not validating a race condition,
+ * rather that the logging framework is not started. This type of test doesn't work well in unit tests
+ * because it requires JVM isolation, and any interactions with a logger invalidate the test.
+ */
+@JCStressTest(Mode.Termination)
+@Outcome(id = "TERMINATED", expect = ACCEPTABLE, desc = "Logger has not been initialized")
+@Outcome(
+        id = "STALE",
+        expect = FORBIDDEN,
+        desc = "Logger has been initialized. This has the potential to cause " +
+                "deadlocks when disruptor is used within logging frameworks")
+public class LoggerInitializationStress
+{
+    private static volatile boolean logManagerInitialized;
+    private static volatile boolean disruptorInitialized;
+    static
+    {
+        System.setProperty("java.util.logging.manager", DisruptorLogManager.class.getCanonicalName());
+    }
+
+    @Actor
+    public void actor() throws Exception
+    {
+        // Wait for a the Disruptor instance to be initialized
+        while (!disruptorInitialized)
+        {
+        }
+        // Validate state
+        if (logManagerInitialized)
+        {
+            throw new RuntimeException("Expected the LogManager to be uninitialized");
+        }
+        Field managerField = LogManager.class.getDeclaredField("manager");
+        Object managerBase = Util.getUnsafe().staticFieldBase(managerField);
+        long managerOffset = Util.getUnsafe().staticFieldOffset(managerField);
+        Object logManager = Util.getUnsafe().getObject(managerBase, managerOffset);
+        if (logManager != null)
+        {
+            throw new RuntimeException("Unexpected LogManager: " + logManager);
+        }
+    }
+
+    @Signal
+    public void signal()
+    {
+        final Disruptor disruptor = new Disruptor<>(
+                SimpleEvent::new,
+                128,
+                Executors.defaultThreadFactory(),
+                ProducerType.MULTI,
+                new BlockingWaitStrategy());
+        disruptor.setDefaultExceptionHandler(SimpleEventExceptionHandler.INSTANCE);
+        disruptor.handleEventsWith(SimpleEventHandler.INSTANCE);
+        disruptor.start();
+        disruptor.halt();
+        disruptorInitialized = true;
+    }
+
+    public static final class DisruptorLogManager extends LogManager
+    {
+        static
+        {
+            logManagerInitialized = true;
+        }
+    }
+
+    public static final class SimpleEvent
+    {
+        private long value = Long.MIN_VALUE;
+
+        public long getValue()
+        {
+            return value;
+        }
+
+        public void setValue(final long value)
+        {
+            this.value = value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "SimpleEvent{" +
+                    "value=" + value +
+                    '}';
+        }
+    }
+
+    public enum SimpleEventHandler implements EventHandler<SimpleEvent>
+    {
+        INSTANCE;
+
+        @Override
+        public void onEvent(final SimpleEvent event, final long sequence, final boolean endOfBatch)
+        {
+            // nop
+        }
+    }
+
+    public enum SimpleEventExceptionHandler implements ExceptionHandler<SimpleEvent>
+    {
+        INSTANCE;
+
+        @Override
+        public void handleEventException(final Throwable ex, final long sequence, final SimpleEvent event)
+        {
+            // nop
+        }
+
+        @Override
+        public void handleOnStartException(final Throwable ex)
+        {
+            // nop
+        }
+
+        @Override
+        public void handleOnShutdownException(final Throwable ex)
+        {
+            // nop
+        }
+    }
+
+}


### PR DESCRIPTION
Validate that creating a Disruptor instance with a custom ExceptionHandler does not
initialize the logging framework. Using JCStress is a stretch, we're not validating a race condition,
rather that the logging framework is not started. This type of test doesn't work well in unit tests
because it requires JVM isolation, and any interactions with a logger invalidate the test.

When disruptor is used within a logging framework, it's crucial that loggers are not accessed internally on initialization because such access is likely to result in deadlocking.

See:
[LOG4J2-2965](https://issues.apache.org/jira/browse/LOG4J2-2965), #370, #371

This JCStress test currently fails on master, but passes when #371 is applied.