### PR TITLE
[3.4] Logger instances are lazily initialized 

### DIFF
--- a/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
+++ b/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
@@ -278,6 +278,10 @@ public final class BatchEventProcessor<T>
     private ExceptionHandler<? super T> getExceptionHandler()
     {
         ExceptionHandler<? super T> handler = exceptionHandler;
-        return handler == null ? ExceptionHandlers.defaultHandler() : handler;
+        if (handler == null)
+        {
+            return ExceptionHandlers.defaultHandler();
+        }
+        return handler;
     }
 }

--- a/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
+++ b/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
@@ -35,7 +35,7 @@ public final class BatchEventProcessor<T>
     private static final int RUNNING = HALTED + 1;
 
     private final AtomicInteger running = new AtomicInteger(IDLE);
-    private ExceptionHandler<? super T> exceptionHandler = new FatalExceptionHandler();
+    private ExceptionHandler<? super T> exceptionHandler;
     private final DataProvider<T> dataProvider;
     private final SequenceBarrier sequenceBarrier;
     private final EventHandler<? super T> eventHandler;
@@ -184,7 +184,7 @@ public final class BatchEventProcessor<T>
             }
             catch (final Throwable ex)
             {
-                exceptionHandler.handleEventException(ex, nextSequence, event);
+                handleEventException(ex, nextSequence, event);
                 sequence.set(nextSequence);
                 nextSequence++;
             }
@@ -208,7 +208,7 @@ public final class BatchEventProcessor<T>
         }
         catch (Throwable e)
         {
-            exceptionHandler.handleEventException(e, availableSequence, null);
+            handleEventException(e, availableSequence, null);
         }
     }
 
@@ -225,7 +225,7 @@ public final class BatchEventProcessor<T>
             }
             catch (final Throwable ex)
             {
-                exceptionHandler.handleOnStartException(ex);
+                handleOnStartException(ex);
             }
         }
     }
@@ -243,8 +243,41 @@ public final class BatchEventProcessor<T>
             }
             catch (final Throwable ex)
             {
-                exceptionHandler.handleOnShutdownException(ex);
+                handleOnShutdownException(ex);
             }
         }
+    }
+
+    /**
+     * Delegate to {@link ExceptionHandler#handleEventException(Throwable, long, Object)} on the delegate or
+     * the default {@link ExceptionHandler} if one has not been configured.
+     */
+    private void handleEventException(final Throwable ex, final long sequence, final T event)
+    {
+        getExceptionHandler().handleEventException(ex, sequence, event);
+    }
+
+    /**
+     * Delegate to {@link ExceptionHandler#handleOnStartException(Throwable)} on the delegate or
+     * the default {@link ExceptionHandler} if one has not been configured.
+     */
+    private void handleOnStartException(final Throwable ex)
+    {
+        getExceptionHandler().handleOnStartException(ex);
+    }
+
+    /**
+     * Delegate to {@link ExceptionHandler#handleOnShutdownException(Throwable)} on the delegate or
+     * the default {@link ExceptionHandler} if one has not been configured.
+     */
+    private void handleOnShutdownException(final Throwable ex)
+    {
+        getExceptionHandler().handleOnShutdownException(ex);
+    }
+
+    private ExceptionHandler<? super T> getExceptionHandler()
+    {
+        ExceptionHandler<? super T> handler = exceptionHandler;
+        return handler == null ? ExceptionHandlers.defaultHandler() : handler;
     }
 }

--- a/src/main/java/com/lmax/disruptor/ExceptionHandlers.java
+++ b/src/main/java/com/lmax/disruptor/ExceptionHandlers.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor;
+
+/** Provides static methods for accessing a default {@link ExceptionHandler} object. */
+public final class ExceptionHandlers
+{
+
+    /**
+     * Get a reference to the default {@link ExceptionHandler} instance.
+     *
+     * @return a reference to the default {@link ExceptionHandler} instance
+     */
+    public static ExceptionHandler<Object> defaultHandler()
+    {
+        return DefaultExceptionHandlerHolder.HANDLER;
+    }
+
+    private ExceptionHandlers()
+    {
+    }
+
+    // lazily initialize the default exception handler.
+    // This nested object isn't strictly necessary unless additional utility functionality is
+    // added to ExceptionHandlers, but it exists to ensure the code remains obvious.
+    private static final class DefaultExceptionHandlerHolder
+    {
+        private static final ExceptionHandler<Object> HANDLER = new FatalExceptionHandler();
+    }
+}

--- a/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
@@ -1,11 +1,11 @@
 package com.lmax.disruptor.dsl;
 
 import com.lmax.disruptor.ExceptionHandler;
-import com.lmax.disruptor.FatalExceptionHandler;
+import com.lmax.disruptor.ExceptionHandlers;
 
 public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
 {
-    private ExceptionHandler<? super T> delegate = new FatalExceptionHandler();
+    private ExceptionHandler<? super T> delegate;
 
     public void switchTo(final ExceptionHandler<? super T> exceptionHandler)
     {
@@ -15,18 +15,24 @@ public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
     @Override
     public void handleEventException(final Throwable ex, final long sequence, final T event)
     {
-        delegate.handleEventException(ex, sequence, event);
+        getExceptionHandler().handleEventException(ex, sequence, event);
     }
 
     @Override
     public void handleOnStartException(final Throwable ex)
     {
-        delegate.handleOnStartException(ex);
+        getExceptionHandler().handleOnStartException(ex);
     }
 
     @Override
     public void handleOnShutdownException(final Throwable ex)
     {
-        delegate.handleOnShutdownException(ex);
+        getExceptionHandler() .handleOnShutdownException(ex);
+    }
+
+    private ExceptionHandler<? super T> getExceptionHandler()
+    {
+        ExceptionHandler<? super T> handler = delegate;
+        return handler == null ? ExceptionHandlers.defaultHandler() : handler;
     }
 }

--- a/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
@@ -33,6 +33,10 @@ public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
     private ExceptionHandler<? super T> getExceptionHandler()
     {
         ExceptionHandler<? super T> handler = delegate;
-        return handler == null ? ExceptionHandlers.defaultHandler() : handler;
+        if (handler == null)
+        {
+            return ExceptionHandlers.defaultHandler();
+        }
+        return handler;
     }
 }


### PR DESCRIPTION
97f7973 is a clean cherry-pick, however the two ternary statements have been replaced with if/else in commit 
5bd1b48 due to the limitations of java 8 generic type inference.

I did not include aa24297 in this PR because the v3.4 branch does not use jcstress.