### PR TITLE
Add javadocs to EventPoller and a related method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - `Disruptor` constructors using Executor have been removed. Use ThreadFactory instead.
     - FatalExceptionHandler and IgnoreExceptionHandler now use the JDK 9 Platform Logging API, i.e. System.Logger
     - Add rewind batch feature to the BatchEventProcessor
+    - Added documentation to EventPoller
 
 ## 3.4.3
 

--- a/src/main/java/com/lmax/disruptor/EventPoller.java
+++ b/src/main/java/com/lmax/disruptor/EventPoller.java
@@ -1,7 +1,10 @@
 package com.lmax.disruptor;
 
 /**
- * Experimental poll-based interface for the Disruptor.
+ * Experimental poll-based interface for the Disruptor. Unlike a {@link BatchEventProcessor},
+ * an event poller allows the user to control the flow of execution. This makes it ideal
+ * for interoperability with existing threads whose lifecycle is not controlled by the
+ * disruptor DSL.
  *
  * @param <T> the type of event used.
  */
@@ -12,16 +15,57 @@ public class EventPoller<T>
     private final Sequence sequence;
     private final Sequence gatingSequence;
 
+    /**
+     * A callback used to process events
+     *
+     * @param <T> the type of the event
+     */
     public interface Handler<T>
     {
+        /**
+         * Called for each event to consume it
+         *
+         * @param event the event
+         * @param sequence the sequence of the event
+         * @param endOfBatch whether this event is the last in the batch
+         * @return whether to continue consuming events. If {@code false}, the poller will not feed any more events
+         *         to the handler until {@link EventPoller#poll(Handler)} is called again
+         * @throws Exception any exceptions thrown by the handler will be propagated to the caller of {@code poll}
+         */
         boolean onEvent(T event, long sequence, boolean endOfBatch) throws Exception;
     }
 
+    /**
+     * Indicates the result of a call to {@link #poll(Handler)}
+     *
+     */
     public enum PollState
     {
-        PROCESSING, GATING, IDLE
+        /**
+         * The poller processed one or more events
+         */
+        PROCESSING,
+        /**
+         * The poller is waiting for gated sequences to advance before events become available
+         *
+         */
+        GATING,
+        /**
+         * No events need to be processed
+         *
+         */
+        IDLE
     }
 
+    /**
+     * Creates an event poller. Most users will want {@link RingBuffer#newPoller(Sequence...)}
+     * which will set up the poller automatically
+     *
+     * @param dataProvider from which events are drawn
+     * @param sequencer the main sequencer which handles ordering of events
+     * @param sequence the sequence which will be used by this event poller
+     * @param gatingSequence the sequences to gate on
+     */
     public EventPoller(
         final DataProvider<T> dataProvider,
         final Sequencer sequencer,
@@ -34,6 +78,19 @@ public class EventPoller<T>
         this.gatingSequence = gatingSequence;
     }
 
+    /**
+     * Polls for events using the given handler. <br>
+     * <br>
+     * This poller will continue to feed events to the given handler until known available
+     * events are consumed or {@link Handler#onEvent(Object, long, boolean)} returns false. <br>
+     * <br>
+     * Note that it is possible for more events to become available while the current events
+     * are being processed. A further call to this method will process such events.
+     *
+     * @param eventHandler the handler used to consume events
+     * @return the state of the event poller after the poll is attempted
+     * @throws Exception exceptions thrown from the event handler are propagated to the caller
+     */
     public PollState poll(final Handler<T> eventHandler) throws Exception
     {
         final long currentSequence = sequence.get();
@@ -74,6 +131,18 @@ public class EventPoller<T>
         }
     }
 
+    /**
+     * Creates an event poller. Most users will want {@link RingBuffer#newPoller(Sequence...)}
+     * which will set up the poller automatically
+     *
+     * @param dataProvider from which events are drawn
+     * @param sequencer the main sequencer which handles ordering of events
+     * @param sequence the sequence which will be used by this event poller
+     * @param cursorSequence the cursor sequence, usually of the ring buffer
+     * @param gatingSequences additional sequences to gate on
+     * @param <T> the type of the event
+     * @return the event poller
+     */
     public static <T> EventPoller<T> newInstance(
         final DataProvider<T> dataProvider,
         final Sequencer sequencer,
@@ -98,6 +167,11 @@ public class EventPoller<T>
         return new EventPoller<>(dataProvider, sequencer, sequence, gatingSequence);
     }
 
+    /**
+     * Get the {@link Sequence} being used by this event poller
+     *
+     * @return the sequence used by the event poller
+     */
     public Sequence getSequence()
     {
         return sequence;

--- a/src/main/java/com/lmax/disruptor/EventPoller.java
+++ b/src/main/java/com/lmax/disruptor/EventPoller.java
@@ -37,7 +37,6 @@ public class EventPoller<T>
 
     /**
      * Indicates the result of a call to {@link #poll(Handler)}
-     *
      */
     public enum PollState
     {
@@ -47,12 +46,10 @@ public class EventPoller<T>
         PROCESSING,
         /**
          * The poller is waiting for gated sequences to advance before events become available
-         *
          */
         GATING,
         /**
          * No events need to be processed
-         *
          */
         IDLE
     }

--- a/src/main/java/com/lmax/disruptor/Sequencer.java
+++ b/src/main/java/com/lmax/disruptor/Sequencer.java
@@ -90,5 +90,13 @@ public interface Sequencer extends Cursored, Sequenced
      */
     long getHighestPublishedSequence(long nextSequence, long availableSequence);
 
+    /**
+     * Creates an event poller from this sequencer
+     *
+     * @param provider from which events are drawn
+     * @param gatingSequences sequences to be gated on
+     * @param <T> the type of the event
+     * @return the event poller
+     */
     <T> EventPoller<T> newPoller(DataProvider<T> provider, Sequence... gatingSequences);
 }


### PR DESCRIPTION
Documentation for EventPoller per #367 

While updating the changelog I noticed that all the changes are listed under "Breaking changes." Perhaps you would like to separate out the breaking changes from the others? You could use 3 categories for breaking changes, deprecations, and the rest.