### PR TITLE
Remove use of Unsafe from Ringbuffer & Util

### DIFF
--- a/src/jcstress/java/com/lmax/disruptor/LoggerInitializationStress.java
+++ b/src/jcstress/java/com/lmax/disruptor/LoggerInitializationStress.java
@@ -2,7 +2,7 @@ package com.lmax.disruptor;
 
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
-import com.lmax.disruptor.util.Util;
+import com.lmax.disruptor.util.UnsafeAccess;
 import org.openjdk.jcstress.annotations.Actor;
 import org.openjdk.jcstress.annotations.JCStressTest;
 import org.openjdk.jcstress.annotations.Mode;
@@ -56,7 +56,7 @@ public class LoggerInitializationStress
         // results in initialization which modifies static state and prevents
         // subsequent runs from executing successfully.
         Field managerField = LogManager.class.getDeclaredField("manager");
-        Unsafe unsafe = Util.getUnsafe();
+        Unsafe unsafe = UnsafeAccess.getUnsafe();
         Object managerBase = unsafe.staticFieldBase(managerField);
         long managerOffset = unsafe.staticFieldOffset(managerField);
         Object logManager = unsafe.getObject(managerBase, managerOffset);

--- a/src/jmh/java/com/lmax/disruptor/ArrayAccessBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/ArrayAccessBenchmark.java
@@ -1,7 +1,7 @@
 package com.lmax.disruptor;
 
 import com.lmax.disruptor.util.SimpleEvent;
-import com.lmax.disruptor.util.Util;
+import com.lmax.disruptor.util.UnsafeAccess;
 import net.openhft.affinity.AffinityLock;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -96,7 +96,7 @@ public class ArrayAccessBenchmark
     private final Object[] entries = new Object[EVENT_COUNT];
     public int sequence;
 
-    private static final Unsafe UNSAFE = Util.getUnsafe();
+    private static final Unsafe UNSAFE = UnsafeAccess.getUnsafe();
     private final int scale = UNSAFE.arrayIndexScale(Object[].class);
     private final int offset = UNSAFE.arrayBaseOffset(Object[].class);
 

--- a/src/jmh/java/com/lmax/disruptor/ArrayAccessBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/ArrayAccessBenchmark.java
@@ -1,0 +1,162 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.util.SimpleEvent;
+import com.lmax.disruptor.util.Util;
+import net.openhft.affinity.AffinityLock;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import sun.misc.Unsafe;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@Threads(1)
+@State(Scope.Thread)
+public class ArrayAccessBenchmark
+{
+    // To run this on a tuned system with benchmark threads pinned to isolated cpus:
+    // Run the JMH process with an env var defining the isolated cpu list, e.g. ISOLATED_CPUS=38,40,42,44,46,48 java -jar disruptor-jmh.jar
+    private static final List<Integer> ISOLATED_CPUS = Arrays.stream(System.getenv().getOrDefault("ISOLATED_CPUS", "").split(","))
+            .map(String::trim)
+            .filter(not(String::isBlank))
+            .map(Integer::valueOf)
+            .collect(Collectors.toList());
+
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+
+    @State(Scope.Thread)
+    public static class ThreadPinningState
+    {
+        int threadId = THREAD_COUNTER.getAndIncrement();
+        private AffinityLock affinityLock;
+
+        @Setup
+        public void setup()
+        {
+            if (ISOLATED_CPUS.size() > 0)
+            {
+                if (threadId > ISOLATED_CPUS.size())
+                {
+                    throw new IllegalArgumentException(
+                            String.format("Benchmark uses at least %d threads, only defined %d isolated cpus",
+                                    threadId,
+                                    ISOLATED_CPUS.size()
+                            ));
+                }
+
+                final Integer cpuId = ISOLATED_CPUS.get(threadId);
+                affinityLock = AffinityLock.acquireLock(cpuId);
+                System.out.printf("Attempted to set thread affinity for %s to %d, success = %b%n",
+                        Thread.currentThread().getName(),
+                        cpuId,
+                        affinityLock.isAllocated()
+                );
+            }
+        }
+
+        @TearDown
+        public void teardown()
+        {
+            if (ISOLATED_CPUS.size() > 0)
+            {
+                affinityLock.release();
+            }
+        }
+    }
+
+    private static final int EVENT_COUNT = 64;
+    private static final int INDEX_MASK = EVENT_COUNT - 1;
+    private final Object[] entries = new Object[EVENT_COUNT];
+    public int sequence;
+
+    private static final Unsafe UNSAFE = Util.getUnsafe();
+    private final int scale = UNSAFE.arrayIndexScale(Object[].class);
+    private final int offset = UNSAFE.arrayBaseOffset(Object[].class);
+
+    private final VarHandle varHandle = MethodHandles.arrayElementVarHandle(Object[].class);
+
+    private final MethodHandle methodHandle = MethodHandles.arrayElementGetter(Object[].class);
+
+    @Setup
+    public void setup()
+    {
+        for (int i = 0; i < EVENT_COUNT; i++)
+        {
+            SimpleEvent simpleEvent = new SimpleEvent();
+            simpleEvent.setValue(i);
+            entries[i] = simpleEvent;
+        }
+
+        sequence = 0;
+    }
+
+    @Benchmark
+    public Object standardArrayAccess(final ThreadPinningState t)
+    {
+        return entries[getNextSequence()];
+    }
+
+    @Benchmark
+    public Object unsafeArrayAccess(final ThreadPinningState t)
+    {
+        return UNSAFE.getObject(entries, offset + ((getNextSequence()) * scale));
+    }
+
+    @Benchmark
+    public Object varHandleArrayAccess(final ThreadPinningState t)
+    {
+        return varHandle.get(entries, getNextSequence());
+    }
+
+    @Benchmark
+    public Object getterMethodHandleInvokeArrayAccess(final ThreadPinningState t) throws Throwable
+    {
+        return methodHandle.invoke(entries, getNextSequence());
+    }
+
+    @Benchmark
+    public Object getterMethodHandleInvokeExactArrayAccess(final ThreadPinningState t) throws Throwable
+    {
+        return methodHandle.invokeExact(entries, getNextSequence());
+    }
+
+    private int getNextSequence()
+    {
+        return sequence++ & INDEX_MASK;
+    }
+
+    public static void main(final String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(ArrayAccessBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/jmh/java/com/lmax/disruptor/RingBufferBenchmark.java
+++ b/src/jmh/java/com/lmax/disruptor/RingBufferBenchmark.java
@@ -1,0 +1,153 @@
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.alternatives.RingBufferArray;
+import com.lmax.disruptor.alternatives.RingBufferUnsafe;
+import com.lmax.disruptor.support.DummyWaitStrategy;
+import com.lmax.disruptor.support.StubEvent;
+import net.openhft.affinity.AffinityLock;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@Threads(1)
+public class RingBufferBenchmark
+{
+    // To run this on a tuned system with benchmark threads pinned to isolated cpus:
+    // Run the JMH process with an env var defining the isolated cpu list, e.g. ISOLATED_CPUS=38,40,42,44,46,48 java -jar disruptor-jmh.jar
+    private static final List<Integer> ISOLATED_CPUS = Arrays.stream(System.getenv().getOrDefault("ISOLATED_CPUS", "").split(","))
+            .map(String::trim)
+            .filter(not(String::isBlank))
+            .map(Integer::valueOf)
+            .collect(Collectors.toList());
+
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+
+    @State(Scope.Thread)
+    public static class ThreadPinningState
+    {
+        int threadId = THREAD_COUNTER.getAndIncrement();
+        private AffinityLock affinityLock;
+
+        @Setup
+        public void setup()
+        {
+            if (ISOLATED_CPUS.size() > 0)
+            {
+                if (threadId > ISOLATED_CPUS.size())
+                {
+                    throw new IllegalArgumentException(
+                            String.format("Benchmark uses at least %d threads, only defined %d isolated cpus",
+                                    threadId,
+                                    ISOLATED_CPUS.size()
+                            ));
+                }
+
+                final Integer cpuId = ISOLATED_CPUS.get(threadId);
+                affinityLock = AffinityLock.acquireLock(cpuId);
+                System.out.printf("Attempted to set thread affinity for %s to %d, success = %b%n",
+                        Thread.currentThread().getName(),
+                        cpuId,
+                        affinityLock.isAllocated()
+                );
+            }
+        }
+
+        @TearDown
+        public void teardown()
+        {
+            if (ISOLATED_CPUS.size() > 0)
+            {
+                affinityLock.release();
+            }
+        }
+    }
+
+    /*
+     * APPROACH 1: RingBufferUnsafe - Using the unsafe API to avoid bounds-checking, as was the case for Disruptor 3.x
+     */
+
+    @State(Scope.Group)
+    public static class StateRingBufferUnsafe
+    {
+        RingBufferUnsafe<Object> ringBufferUnsafe = new RingBufferUnsafe<>(
+                () -> new StubEvent(-1),
+                new SingleProducerSequencer(128, new DummyWaitStrategy()));
+    }
+
+    @Benchmark
+    @Group("RingBufferUnsafe")
+    public Object readUnsafe(final StateRingBufferUnsafe ringBufferUnsafe, final ThreadPinningState t)
+    {
+        return ringBufferUnsafe.ringBufferUnsafe.get(64);
+    }
+
+    @Benchmark
+    @Group("RingBufferUnsafe")
+    public void writeUnsafe(final StateRingBufferUnsafe ringBufferUnsafe, final ThreadPinningState t)
+    {
+        ringBufferUnsafe.ringBufferUnsafe.publish(64);
+    }
+
+    /*
+     * APPROACH 2: RingBufferArray - There is no support for non-bounds-checked array element access as there was via
+     * unsafe. So the simplest approach is to go back to a plain array and index to elements.
+     */
+
+    @State(Scope.Group)
+    public static class StateRingBufferArray
+    {
+        RingBufferArray<Object> ringBufferVarHandle = new RingBufferArray<>(
+                () -> new StubEvent(-1),
+                new SingleProducerSequencer(128, new DummyWaitStrategy())
+        );
+    }
+
+    @Benchmark
+    @Group("RingBufferArray")
+    public Object readArray(final StateRingBufferArray ringBufferVarHandle, final ThreadPinningState t)
+    {
+        return ringBufferVarHandle.ringBufferVarHandle.get(64);
+    }
+
+    @Benchmark
+    @Group("RingBufferArray")
+    public void writeArray(final StateRingBufferArray ringBufferVarHandle, final ThreadPinningState t)
+    {
+        ringBufferVarHandle.ringBufferVarHandle.publish(64);
+    }
+
+    public static void main(final String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(RingBufferBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/main/java/com/lmax/disruptor/util/Util.java
+++ b/src/main/java/com/lmax/disruptor/util/Util.java
@@ -17,11 +17,6 @@ package com.lmax.disruptor.util;
 
 import com.lmax.disruptor.EventProcessor;
 import com.lmax.disruptor.Sequence;
-import sun.misc.Unsafe;
-
-import java.lang.reflect.Field;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 
 /**
  * Set of common functions used by the Disruptor.
@@ -90,38 +85,6 @@ public final class Util
         }
 
         return sequences;
-    }
-
-    private static final Unsafe THE_UNSAFE;
-
-    static
-    {
-        try
-        {
-            final PrivilegedExceptionAction<Unsafe> action = () ->
-            {
-                Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
-                theUnsafe.setAccessible(true);
-                return (Unsafe) theUnsafe.get(null);
-            };
-
-            THE_UNSAFE = AccessController.doPrivileged(action);
-        }
-        catch (Exception e)
-        {
-            throw new RuntimeException("Unable to load unsafe", e);
-        }
-    }
-
-    /**
-     * Get a handle on the Unsafe instance, used for accessing low-level concurrency
-     * and memory constructs.
-     *
-     * @return The Unsafe
-     */
-    public static Unsafe getUnsafe()
-    {
-        return THE_UNSAFE;
     }
 
     /**

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,4 @@
 module com.lmax.disruptor {
-    requires jdk.unsupported; // Temporarily required for sum.misc.Unsafe until Unsafe is removed
-
     exports com.lmax.disruptor;
     exports com.lmax.disruptor.dsl;
     exports com.lmax.disruptor.util;

--- a/src/test/java/com/lmax/disruptor/alternatives/MultiProducerSequencerUnsafe.java
+++ b/src/test/java/com/lmax/disruptor/alternatives/MultiProducerSequencerUnsafe.java
@@ -20,6 +20,7 @@ import com.lmax.disruptor.InsufficientCapacityException;
 import com.lmax.disruptor.Sequence;
 import com.lmax.disruptor.Sequencer;
 import com.lmax.disruptor.WaitStrategy;
+import com.lmax.disruptor.util.UnsafeAccess;
 import com.lmax.disruptor.util.Util;
 import sun.misc.Unsafe;
 
@@ -36,7 +37,7 @@ import java.util.concurrent.locks.LockSupport;
  */
 public final class MultiProducerSequencerUnsafe extends AbstractSequencer
 {
-    private static final Unsafe UNSAFE = Util.getUnsafe();
+    private static final Unsafe UNSAFE = UnsafeAccess.getUnsafe();
     private static final long BASE = UNSAFE.arrayBaseOffset(int[].class);
     private static final long SCALE = UNSAFE.arrayIndexScale(int[].class);
 

--- a/src/test/java/com/lmax/disruptor/alternatives/RingBufferUnsafe.java
+++ b/src/test/java/com/lmax/disruptor/alternatives/RingBufferUnsafe.java
@@ -20,7 +20,7 @@ import com.lmax.disruptor.Sequencer;
 import com.lmax.disruptor.SingleProducerSequencer;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.ProducerType;
-import com.lmax.disruptor.util.Util;
+import com.lmax.disruptor.util.UnsafeAccess;
 import sun.misc.Unsafe;
 
 abstract class RingBufferPadUnsafe
@@ -40,7 +40,7 @@ abstract class RingBufferFieldsUnsafe<E> extends RingBufferPadUnsafe
     private static final int BUFFER_PAD;
     private static final long REF_ARRAY_BASE;
     private static final int REF_ELEMENT_SHIFT;
-    private static final Unsafe UNSAFE = Util.getUnsafe();
+    private static final Unsafe UNSAFE = UnsafeAccess.getUnsafe();
 
     private static final int POINTER_SIZE_32_BIT = 4;
     private static final int BITSHIFT_MULTIPLIER_FOUR = 2;

--- a/src/test/java/com/lmax/disruptor/alternatives/SequenceDoublePadded.java
+++ b/src/test/java/com/lmax/disruptor/alternatives/SequenceDoublePadded.java
@@ -15,7 +15,7 @@
  */
 package com.lmax.disruptor.alternatives;
 
-import com.lmax.disruptor.util.Util;
+import com.lmax.disruptor.util.UnsafeAccess;
 import sun.misc.Unsafe;
 
 // https://github.com/LMAX-Exchange/disruptor/issues/231
@@ -55,7 +55,7 @@ public class SequenceDoublePadded extends RhsPaddingDouble
 
     static
     {
-        UNSAFE = Util.getUnsafe();
+        UNSAFE = UnsafeAccess.getUnsafe();
         try
         {
             VALUE_OFFSET = UNSAFE.objectFieldOffset(ValueDoublePadded.class.getDeclaredField("value"));

--- a/src/test/java/com/lmax/disruptor/alternatives/SequenceUnsafe.java
+++ b/src/test/java/com/lmax/disruptor/alternatives/SequenceUnsafe.java
@@ -1,6 +1,6 @@
 package com.lmax.disruptor.alternatives;
 
-import com.lmax.disruptor.util.Util;
+import com.lmax.disruptor.util.UnsafeAccess;
 import sun.misc.Unsafe;
 
 class LhsPaddingUnsafe
@@ -48,7 +48,7 @@ public class SequenceUnsafe extends RhsPaddingUnsafe
 
     static
     {
-        UNSAFE = Util.getUnsafe();
+        UNSAFE = UnsafeAccess.getUnsafe();
         try
         {
             VALUE_OFFSET = UNSAFE.objectFieldOffset(ValueUnsafe.class.getDeclaredField("value"));

--- a/src/test/java/com/lmax/disruptor/util/UnsafeAccess.java
+++ b/src/test/java/com/lmax/disruptor/util/UnsafeAccess.java
@@ -1,0 +1,40 @@
+package com.lmax.disruptor.util;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+
+public class UnsafeAccess
+{
+    private static final sun.misc.Unsafe THE_UNSAFE;
+
+    static
+    {
+        try
+        {
+            final PrivilegedExceptionAction<sun.misc.Unsafe> action = () ->
+            {
+                Field theUnsafe = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+                theUnsafe.setAccessible(true);
+                return (sun.misc.Unsafe) theUnsafe.get(null);
+            };
+
+            THE_UNSAFE = AccessController.doPrivileged(action);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Unable to load unsafe", e);
+        }
+    }
+
+    /**
+     * Get a handle on the Unsafe instance, used for accessing low-level concurrency
+     * and memory constructs.
+     *
+     * @return The Unsafe
+     */
+    public static sun.misc.Unsafe getUnsafe()
+    {
+        return THE_UNSAFE;
+    }
+}


### PR DESCRIPTION
For #345 we aim to remove dependency on `sun.misc.Unsafe`

Change the RingBuffer to use a plain array access instead of using Unsafe, which appears to have been used in an attempt at speed gains only, no concurrency focus.
I have also added a start of a benchmark on array access to try standard, Unsafe, VarHandle, and MethodHandles to compare. It seems that standard array access is the winner.

As this was the last use of `Unsafe` in the main code, `Util::getUnsafe` could be removed from the main source and put in as a test util, given we still use `Unsafe` in tests (primarily for benchmarking and concurrency verification).