### PR TITLE
Use a logical rather than bitwise AND in `EventPoller`

### DIFF
--- a/src/main/java/com/lmax/disruptor/EventPoller.java
+++ b/src/main/java/com/lmax/disruptor/EventPoller.java
@@ -109,7 +109,7 @@ public class EventPoller<T>
                     nextSequence++;
 
                 }
-                while (nextSequence <= availableSequence & processNextEvent);
+                while (nextSequence <= availableSequence && processNextEvent);
             }
             finally
             {


### PR DESCRIPTION
As far as I can tell, there doesn't appear to be a good reason for using `&` here over `&&`?