### PR TITLE
Fix shouldNotPassZeroSizeToBatchStartAware

### DIFF
--- a/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
+++ b/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
@@ -280,9 +280,7 @@ public final class BatchEventProcessorTest
     @Test
     public void shouldNotPassZeroSizeToBatchStartAware() throws Exception
     {
-        final CountDownLatch latch = new CountDownLatch(3);
-
-        BatchAwareEventHandler eventHandler = new BatchAwareEventHandler(latch);
+        BatchAwareEventHandler eventHandler = new BatchAwareEventHandler();
 
         final BatchEventProcessor<StubEvent> batchEventProcessor = new BatchEventProcessor<>(
                 ringBuffer, new DelegatingSequenceBarrier(this.sequenceBarrier), eventHandler);
@@ -291,11 +289,14 @@ public final class BatchEventProcessorTest
 
         Thread thread = new Thread(batchEventProcessor);
         thread.start();
-        latch.await(2, TimeUnit.SECONDS);
 
-        ringBuffer.publish(ringBuffer.next());
-        ringBuffer.publish(ringBuffer.next());
-        ringBuffer.publish(ringBuffer.next());
+        for (int i = 0; i < 3; i++)
+        {
+            final long sequence = ringBuffer.next();
+            Thread.sleep(100);
+
+            ringBuffer.publish(sequence);
+        }
 
         batchEventProcessor.halt();
         thread.join();
@@ -353,13 +354,13 @@ public final class BatchEventProcessorTest
         }
     }
 
-    private static class BatchAwareEventHandler extends LatchEventHandler implements BatchStartAware
+    private static class BatchAwareEventHandler implements EventHandler<StubEvent>, BatchStartAware
     {
         final Map<Long, Integer> batchSizeToCountMap = new HashMap<>();
 
-        BatchAwareEventHandler(final CountDownLatch latch)
+        @Override
+        public void onEvent(final StubEvent event, final long sequence, final boolean endOfBatch) throws Exception
         {
-            super(latch);
         }
 
         @Override
@@ -370,5 +371,4 @@ public final class BatchEventProcessorTest
             batchSizeToCountMap.put(batchSize, nextCount);
         }
     }
-
 }


### PR DESCRIPTION
The test setups a latch that is decremented on-event, and then waits on the latch before publishing any event.
Here, `latch.await(2, TimeUnit.SECONDS);` is just a complex equivalent to `Thread.sleep(2000)`, and it makes the test quite slow.

The behavior under test can be validated by increasing the sequencer number, which will unblock `SequenceBarrier.waitFor` in multi-producer mode, and then by waiting before publishing the sequence.