### PR TITLE
Assert that only a single thread accesses a SingleProducerSequencer.

### DIFF
--- a/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
@@ -71,7 +71,8 @@ public final class SingleProducerSequencer extends SingleProducerSequencerFields
         p70, p71, p72, p73, p74, p75, p76, p77;
 
     /**
-     * <p>Only used when assertions are enabled.
+     * Only used when assertions are enabled.
+     *
      * <p>Used for asserting that only one thread publishes to this Sequencer.
      * I.e. helps developers detect early if they use the wrong
      * {@link com.lmax.disruptor.dsl.ProducerType}.

--- a/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
@@ -278,17 +278,18 @@ public final class SingleProducerSequencer extends SingleProducerSequencerFields
          * I.e. it helps developers detect early if they use the wrong
          * {@link com.lmax.disruptor.dsl.ProducerType}.
          */
-        private static final Map<SingleProducerSequencer, Thread> producers = new HashMap<>();
+        private static final Map<SingleProducerSequencer, Thread> PRODUCERS = new HashMap<>();
 
-        public static boolean isSameThreadProducingTo(final SingleProducerSequencer singleProducerSequencer) {
-            synchronized (producers)
+        public static boolean isSameThreadProducingTo(final SingleProducerSequencer singleProducerSequencer)
+        {
+            synchronized (PRODUCERS)
             {
                 final Thread currentThread = Thread.currentThread();
-                if (!producers.containsKey(singleProducerSequencer))
+                if (!PRODUCERS.containsKey(singleProducerSequencer))
                 {
-                    producers.put(singleProducerSequencer, currentThread);
+                    PRODUCERS.put(singleProducerSequencer, currentThread);
                 }
-                return producers.get(singleProducerSequencer).equals(currentThread);
+                return PRODUCERS.get(singleProducerSequencer).equals(currentThread);
             }
         }
     }

--- a/src/test/java/com/lmax/disruptor/SequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/SequencerTest.java
@@ -3,7 +3,6 @@ package com.lmax.disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.support.DummyWaitStrategy;
 import com.lmax.disruptor.util.DaemonThreadFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/src/test/java/com/lmax/disruptor/SequencerTest.java
+++ b/src/test/java/com/lmax/disruptor/SequencerTest.java
@@ -3,6 +3,8 @@ package com.lmax.disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import com.lmax.disruptor.support.DummyWaitStrategy;
 import com.lmax.disruptor.util.DaemonThreadFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -52,6 +54,17 @@ public class SequencerTest
         }
     }
 
+    @Test
+    public void shouldThrowAssertionErrorIfTwoThreadsPublishToSingleProducer() throws InterruptedException
+    {
+        Sequencer sequencer = new SingleProducerSequencer(BUFFER_SIZE, new BlockingWaitStrategy());
+        Thread otherThread  = new Thread(sequencer::next);
+        otherThread.start();
+        otherThread.join();
+
+        assertThrows(AssertionError.class, sequencer::next);
+    }
+
     @ParameterizedTest
     @MethodSource("sequencerGenerator")
     public void shouldStartWithInitialValue(final Sequencer sequencer)
@@ -99,20 +112,22 @@ public class SequencerTest
         throws InterruptedException
     {
         sequencer.addGatingSequences(gatingSequence);
-        long sequence = sequencer.next(BUFFER_SIZE);
-        sequencer.publish(sequence - (BUFFER_SIZE - 1), sequence);
 
         final CountDownLatch waitingLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
         final long expectedFullSequence = Sequencer.INITIAL_CURSOR_VALUE + sequencer.getBufferSize();
-        assertThat(
-            sequencer.getHighestPublishedSequence(Sequencer.INITIAL_CURSOR_VALUE + 1, sequencer.getCursor()),
-            is(expectedFullSequence));
 
         executor.submit(
                 () ->
                 {
+                    long sequence = sequencer.next(BUFFER_SIZE);
+                    sequencer.publish(sequence - (BUFFER_SIZE - 1), sequence);
+
+                    assertThat(
+                            sequencer.getHighestPublishedSequence(Sequencer.INITIAL_CURSOR_VALUE + 1, sequencer.getCursor()),
+                            is(expectedFullSequence));
+
                     waitingLatch.countDown();
 
                     long next = sequencer.next();


### PR DESCRIPTION
If a developer uses the wrong ProducerType, it's hard to detect.

This commit adds a check using assertions so a developer can fail in
test instead of being burnt in Production.
(There will be no runtime cost in Production.)

As can be seen from the commit, there was actually a test case that
started failing because a SingleProducerSequencer was accessed by two
threads...