### PR TITLE
Make images work in both IDEA and Gradle

### DIFF
--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -31,7 +31,8 @@ asciidoctor {
     attributes 'source-highlighter': 'pygments',
             'toc': 'left',
             'icons': 'font',
-            'xrefstyle': 'short'
+            'xrefstyle': 'short',
+            'imagesdir': '.'
     copyResourcesOnlyIf 'html5'
     baseDirFollowsSourceFile()
 

--- a/src/docs/asciidoc/en/disruptor.adoc
+++ b/src/docs/asciidoc/en/disruptor.adoc
@@ -13,6 +13,7 @@ v1.0, May 2011
 :xrefstyle: short
 :icons: font
 :gradle-rootdir: ../../../../
+:imagesdir: ../../
 
 https://github.com/LMAX-Exchange/disruptor
 

--- a/src/docs/asciidoc/en/index.adoc
+++ b/src/docs/asciidoc/en/index.adoc
@@ -9,6 +9,7 @@ High Performance Inter-Thread Messaging Library
 :xrefstyle: short
 :icons: font
 :gradle-rootdir: ../../../../
+:imagesdir: ../../
 
 == Read This First
 
@@ -52,7 +53,7 @@ It's fast.
 Very fast.
 
 .Latency histogram comparing Disruptor to ArrayBlockingQueue
-image::./resources/images/latency-histogram.png[]
+image::resources/images/latency-histogram.png[]
 
 Note that this is a log-log scale, not linear.
 If we tried to plot the comparisons on a linear scale, we'd run out of space very quickly.

--- a/src/docs/asciidoc/en/user-guide/10_using_the_disruptor.adoc
+++ b/src/docs/asciidoc/en/user-guide/10_using_the_disruptor.adoc
@@ -8,6 +8,7 @@
 :xrefstyle: short
 :icons: font
 :gradle-rootdir: ../../../../../
+:imagesdir: ../../
 
 == Introduction
 

--- a/src/docs/asciidoc/en/user-guide/index.adoc
+++ b/src/docs/asciidoc/en/user-guide/index.adoc
@@ -8,6 +8,7 @@
 :xrefstyle: short
 :icons: font
 :gradle-rootdir: ../../../../../
+:imagesdir: ../../
 
 The LMAX Disruptor is a high performance inter-thread messaging library. It grew out of LMAX's research into concurrency, performance and non-blocking algorithms and today forms a core part of their Exchange's infrastructure.
 


### PR DESCRIPTION
As per [eddieHRS](https://github.com/eddieHRS)'s comment, we can default the `imagesdir` property in the `.adoc` files to be IDEA friendly, and then override the value for this to something more appropriate for Gradle when building. This seems like it works for both situations.

Fixes #431