### PR TITLE
Add max batch size limit to BatchEventProcessor

### DIFF
--- a/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
+++ b/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
@@ -33,6 +33,7 @@ public final class BatchEventProcessor<T>
     private static final int IDLE = 0;
     private static final int HALTED = IDLE + 1;
     private static final int RUNNING = HALTED + 1;
+    private static final int DEFAULT_MAX_BATCH_SIZE = Integer.MAX_VALUE;
 
     private final AtomicInteger running = new AtomicInteger(IDLE);
     private ExceptionHandler<? super T> exceptionHandler;
@@ -86,7 +87,7 @@ public final class BatchEventProcessor<T>
             final EventHandler<? super T> eventHandler
     )
     {
-        this(dataProvider, sequenceBarrier, eventHandler, Integer.MAX_VALUE);
+        this(dataProvider, sequenceBarrier, eventHandler, DEFAULT_MAX_BATCH_SIZE);
     }
 
     @Override

--- a/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
+++ b/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
@@ -196,9 +196,9 @@ public final class BatchEventProcessor<T>
                     final long availableSequence = sequenceBarrier.waitFor(nextSequence);
                     final long endOfBatchSequence = min(nextSequence + batchLimitOffset, availableSequence);
 
-                    if (endOfBatchSequence >= nextSequence)
+                    if (nextSequence <= endOfBatchSequence)
                     {
-                        eventHandler.onBatchStart(endOfBatchSequence - nextSequence + 1);
+                        eventHandler.onBatchStart(endOfBatchSequence - nextSequence + 1, availableSequence - nextSequence + 1);
                     }
 
                     while (nextSequence <= endOfBatchSequence)

--- a/src/main/java/com/lmax/disruptor/EventHandler.java
+++ b/src/main/java/com/lmax/disruptor/EventHandler.java
@@ -42,8 +42,9 @@ public interface EventHandler<T>
      * Invoked by {@link BatchEventProcessor} prior to processing a batch of events
      *
      * @param batchSize the size of the batch that is starting
+     * @param queueDepth the total number of queued up events including the batch about to be processed
      */
-    default void onBatchStart(long batchSize)
+    default void onBatchStart(long batchSize, long queueDepth)
     {
     }
 

--- a/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOffHeapThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOffHeapThroughputTest.java
@@ -136,7 +136,7 @@ public class OneToOneOffHeapThroughputTest extends AbstractPerfTestDisruptor
         }
 
         @Override
-        public void onBatchStart(final long batchSize)
+        public void onBatchStart(final long batchSize, final long queueDepth)
         {
             batchesProcessed.increment();
         }

--- a/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
+++ b/src/perftest/java/com/lmax/disruptor/offheap/OneToOneOnHeapThroughputTest.java
@@ -140,7 +140,7 @@ public class OneToOneOnHeapThroughputTest extends AbstractPerfTestDisruptor
         }
 
         @Override
-        public void onBatchStart(final long batchSize)
+        public void onBatchStart(final long batchSize, final long queueDepth)
         {
             batchesProcessed.increment();
         }

--- a/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/LongArrayEventHandler.java
@@ -60,7 +60,7 @@ public final class LongArrayEventHandler implements EventHandler<long[]>
     }
 
     @Override
-    public void onBatchStart(final long batchSize)
+    public void onBatchStart(final long batchSize, final long queueDepth)
     {
         batchesProcessed.increment();
     }

--- a/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueAdditionEventHandler.java
@@ -57,7 +57,7 @@ public final class ValueAdditionEventHandler implements EventHandler<ValueEvent>
     }
 
     @Override
-    public void onBatchStart(final long batchSize)
+    public void onBatchStart(final long batchSize, final long queueDepth)
     {
         batchesProcessed.increment();
     }

--- a/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
+++ b/src/perftest/java/com/lmax/disruptor/support/ValueMutationEventHandler.java
@@ -63,7 +63,7 @@ public final class ValueMutationEventHandler implements EventHandler<ValueEvent>
     }
 
     @Override
-    public void onBatchStart(final long batchSize)
+    public void onBatchStart(final long batchSize, final long queueDepth)
     {
         batchesProcessed.increment();
     }

--- a/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
+++ b/src/test/java/com/lmax/disruptor/BatchEventProcessorTest.java
@@ -162,7 +162,7 @@ public final class BatchEventProcessorTest
         {
 
             @Override
-            public void onBatchStart(final long batchSize)
+            public void onBatchStart(final long batchSize, final long queueDepth)
             {
                 batchSizes.add(batchSize);
             }
@@ -364,7 +364,7 @@ public final class BatchEventProcessorTest
         }
 
         @Override
-        public void onBatchStart(final long batchSize)
+        public void onBatchStart(final long batchSize, final long queueDepth)
         {
             final Integer currentCount = batchSizeToCountMap.get(batchSize);
             final int nextCount = null == currentCount ? 1 : currentCount + 1;

--- a/src/test/java/com/lmax/disruptor/MaxBatchSizeEventProcessorTest.java
+++ b/src/test/java/com/lmax/disruptor/MaxBatchSizeEventProcessorTest.java
@@ -71,7 +71,7 @@ public final class MaxBatchSizeEventProcessorTest
     }
 
     @Test
-    public void shouldAnnounceBatchSizeAtTheStartOfBatch() throws Exception
+    public void shouldAnnounceBatchSizeAndQueueDepthAtTheStartOfBatch() throws Exception
     {
         long sequence = 0;
         for (int i = 0; i < PUBLISH_COUNT; i++)
@@ -84,6 +84,7 @@ public final class MaxBatchSizeEventProcessorTest
         countDownLatch.await();
 
         assertEquals(eventHandler.announcedBatchSizes, Arrays.asList(3L, 2L));
+        assertEquals(eventHandler.announcedQueueDepths, Arrays.asList(5L, 2L));
     }
 
     @AfterEach
@@ -99,6 +100,7 @@ public final class MaxBatchSizeEventProcessorTest
         private List<Long> currentSequences;
         private final CountDownLatch countDownLatch;
         private final List<Long> announcedBatchSizes = new ArrayList<>();
+        private final List<Long> announcedQueueDepths = new ArrayList<>();
 
         BatchLimitRecordingHandler(final CountDownLatch countDownLatch)
         {
@@ -119,10 +121,11 @@ public final class MaxBatchSizeEventProcessorTest
         }
 
         @Override
-        public void onBatchStart(final long batchSize)
+        public void onBatchStart(final long batchSize, final long queueDepth)
         {
             currentSequences = new ArrayList<>();
             announcedBatchSizes.add(batchSize);
+            announcedQueueDepths.add(queueDepth);
         }
     }
 }

--- a/src/test/java/com/lmax/disruptor/MaxBatchSizeEventProcessorTest.java
+++ b/src/test/java/com/lmax/disruptor/MaxBatchSizeEventProcessorTest.java
@@ -57,15 +57,7 @@ public final class MaxBatchSizeEventProcessorTest
     @Test
     public void shouldLimitTheBatchToConfiguredMaxBatchSize() throws Exception
     {
-        long sequence = 0;
-        for (int i = 0; i < PUBLISH_COUNT; i++)
-        {
-            sequence = ringBuffer.next();
-        }
-        ringBuffer.publish(sequence);
-
-         //Wait for consumer to process all events
-        countDownLatch.await();
+        publishEvents();
 
         assertEquals(eventHandler.batchedSequences, Arrays.asList(Arrays.asList(0L, 1L, 2L), Arrays.asList(3L, 4L)));
     }
@@ -73,15 +65,7 @@ public final class MaxBatchSizeEventProcessorTest
     @Test
     public void shouldAnnounceBatchSizeAndQueueDepthAtTheStartOfBatch() throws Exception
     {
-        long sequence = 0;
-        for (int i = 0; i < PUBLISH_COUNT; i++)
-        {
-            sequence = ringBuffer.next();
-        }
-        ringBuffer.publish(sequence);
-
-        //Wait for consumer to process all events
-        countDownLatch.await();
+        publishEvents();
 
         assertEquals(eventHandler.announcedBatchSizes, Arrays.asList(3L, 2L));
         assertEquals(eventHandler.announcedQueueDepths, Arrays.asList(5L, 2L));
@@ -92,6 +76,19 @@ public final class MaxBatchSizeEventProcessorTest
     {
         batchEventProcessor.halt();
         thread.join();
+    }
+
+    private void publishEvents() throws InterruptedException
+    {
+        long sequence = 0;
+        for (int i = 0; i < PUBLISH_COUNT; i++)
+        {
+            sequence = ringBuffer.next();
+        }
+        ringBuffer.publish(sequence);
+
+        //Wait for consumer to process all events
+        countDownLatch.await();
     }
 
     private static class BatchLimitRecordingHandler implements EventHandler<StubEvent>

--- a/src/test/java/com/lmax/disruptor/MaxBatchSizeEventProcessorTest.java
+++ b/src/test/java/com/lmax/disruptor/MaxBatchSizeEventProcessorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor;
+
+import com.lmax.disruptor.support.StubEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static com.lmax.disruptor.RingBuffer.createSingleProducer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class MaxBatchSizeEventProcessorTest
+{
+    public static final int MAX_BATCH_SIZE = 3;
+    public static final int PUBLISH_COUNT = 5;
+    private final RingBuffer<StubEvent> ringBuffer = createSingleProducer(StubEvent.EVENT_FACTORY, 16);
+    private final SequenceBarrier sequenceBarrier = ringBuffer.newBarrier();
+    private CountDownLatch countDownLatch;
+    private BatchEventProcessor<StubEvent> batchEventProcessor;
+    private Thread thread;
+    private BatchLimitRecordingHandler eventHandler;
+
+    @BeforeEach
+    void setUp()
+    {
+        countDownLatch = new CountDownLatch(PUBLISH_COUNT);
+        eventHandler = new BatchLimitRecordingHandler(countDownLatch);
+
+        batchEventProcessor = new BatchEventProcessor<>(
+                ringBuffer, this.sequenceBarrier, eventHandler, MAX_BATCH_SIZE);
+
+        ringBuffer.addGatingSequences(batchEventProcessor.getSequence());
+
+        thread = new Thread(batchEventProcessor);
+        thread.start();
+    }
+
+    @Test
+    public void shouldLimitTheBatchToConfiguredMaxBatchSize() throws Exception
+    {
+        long sequence = 0;
+        for (int i = 0; i < PUBLISH_COUNT; i++)
+        {
+            sequence = ringBuffer.next();
+        }
+        ringBuffer.publish(sequence);
+
+         //Wait for consumer to process all events
+        countDownLatch.await();
+
+        assertEquals(eventHandler.batchedSequences, Arrays.asList(Arrays.asList(0L, 1L, 2L), Arrays.asList(3L, 4L)));
+    }
+
+    @Test
+    public void shouldAnnounceBatchSizeAtTheStartOfBatch() throws Exception
+    {
+        long sequence = 0;
+        for (int i = 0; i < PUBLISH_COUNT; i++)
+        {
+            sequence = ringBuffer.next();
+        }
+        ringBuffer.publish(sequence);
+
+        //Wait for consumer to process all events
+        countDownLatch.await();
+
+        assertEquals(eventHandler.announcedBatchSizes, Arrays.asList(3L, 2L));
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException
+    {
+        batchEventProcessor.halt();
+        thread.join();
+    }
+
+    private static class BatchLimitRecordingHandler implements EventHandler<StubEvent>
+    {
+        public final List<List<Long>> batchedSequences = new ArrayList<>();
+        private List<Long> currentSequences;
+        private final CountDownLatch countDownLatch;
+        private final List<Long> announcedBatchSizes = new ArrayList<>();
+
+        BatchLimitRecordingHandler(final CountDownLatch countDownLatch)
+        {
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public void onEvent(final StubEvent event, final long sequence, final boolean endOfBatch) throws Exception
+        {
+            currentSequences.add(sequence);
+            if (endOfBatch)
+            {
+                batchedSequences.add(currentSequences);
+                currentSequences = null;
+            }
+
+            countDownLatch.countDown();
+        }
+
+        @Override
+        public void onBatchStart(final long batchSize)
+        {
+            currentSequences = new ArrayList<>();
+            announcedBatchSizes.add(batchSize);
+        }
+    }
+}


### PR DESCRIPTION
Add an optional `maxBatchSize` parameter to `BatchEventProcessor`.

Defaults to `Integer.MAX_VALUE`.

Limits the amount of events that will be processed before updating the sequence in the `BatchEventProcessor`.

Closes #438 