### PR TITLE
Retryable RewindAction and miscellaneous improvements. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ pom.xml
 *.ipr
 *.iws
 *-gc.log
-gradle.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+# Project-wide Gradle settings.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m
+
+# When configured, Gradle will run in parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
+++ b/src/main/java/com/lmax/disruptor/BatchEventProcessor.java
@@ -187,16 +187,23 @@ public final class BatchEventProcessor<T>
                 catch (final RewindableException e)
                 {
                     final var action = batchRewindStrategy.handleRewindException(e, ++retriesAttempted);
-                    if (action == REWIND) {
+                    if (action == REWIND)
+                    {
                         nextSequence = startOfBatchSequence;
-                    } else if (action == RETRY) {
+                    }
+                    else if (action == RETRY)
+                    {
                         // continue from current value of nextSequence
                         // effectively a no-op
                         continue;
-                    } else if (action == THROW) {
+                    }
+                    else if (action == THROW)
+                    {
                         retriesAttempted = 0;
                         throw e;
-                    } else {
+                    }
+                    else
+                    {
                         throw new IllegalStateException("Unhandled RewindAction: " + action);
                     }
                 }

--- a/src/main/java/com/lmax/disruptor/BatchRewindStrategy.java
+++ b/src/main/java/com/lmax/disruptor/BatchRewindStrategy.java
@@ -3,6 +3,7 @@ package com.lmax.disruptor;
 /**
  * Strategy for handling a rewindableException when processing an event.
  */
+
 public interface BatchRewindStrategy
 {
 

--- a/src/main/java/com/lmax/disruptor/BatchRewindStrategy.java
+++ b/src/main/java/com/lmax/disruptor/BatchRewindStrategy.java
@@ -3,7 +3,7 @@ package com.lmax.disruptor;
 /**
  * Strategy for handling a rewindableException when processing an event.
  */
-
+@FunctionalInterface
 public interface BatchRewindStrategy
 {
 

--- a/src/main/java/com/lmax/disruptor/Cursored.java
+++ b/src/main/java/com/lmax/disruptor/Cursored.java
@@ -21,6 +21,7 @@ package com.lmax.disruptor;
  * add/remove of Sequences from a
  * {@link SequenceGroups#addSequences(Object, java.util.concurrent.atomic.AtomicReferenceFieldUpdater, Cursored, Sequence...)}.
  */
+@FunctionalInterface
 public interface Cursored
 {
     /**

--- a/src/main/java/com/lmax/disruptor/DataProvider.java
+++ b/src/main/java/com/lmax/disruptor/DataProvider.java
@@ -20,6 +20,7 @@ package com.lmax.disruptor;
  *
  * @param <T> The type provided by the implementation
  */
+@FunctionalInterface
 public interface DataProvider<T>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventFactory.java
+++ b/src/main/java/com/lmax/disruptor/EventFactory.java
@@ -20,6 +20,7 @@ package com.lmax.disruptor;
  *
  * @param <T> event implementation storing the data for sharing during exchange or parallel coordination of an event.
  */
+@FunctionalInterface
 public interface EventFactory<T>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventHandler.java
+++ b/src/main/java/com/lmax/disruptor/EventHandler.java
@@ -21,6 +21,7 @@ package com.lmax.disruptor;
  * @param <T> event implementation storing the data for sharing during exchange or parallel coordination of an event.
  * @see BatchEventProcessor#setExceptionHandler(ExceptionHandler) if you want to handle exceptions propagated out of the handler.
  */
+@FunctionalInterface
 public interface EventHandler<T>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventTranslator.java
+++ b/src/main/java/com/lmax/disruptor/EventTranslator.java
@@ -24,6 +24,7 @@ package com.lmax.disruptor;
  *
  * @param <T> event implementation storing the data for sharing during exchange or parallel coordination of an event.
  */
+@FunctionalInterface
 public interface EventTranslator<T>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventTranslatorOneArg.java
+++ b/src/main/java/com/lmax/disruptor/EventTranslatorOneArg.java
@@ -22,6 +22,7 @@ package com.lmax.disruptor;
  * @param <A> type first user specified argument to the translator.
  * @see EventTranslator
  */
+@FunctionalInterface
 public interface EventTranslatorOneArg<T, A>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventTranslatorThreeArg.java
+++ b/src/main/java/com/lmax/disruptor/EventTranslatorThreeArg.java
@@ -24,6 +24,7 @@ package com.lmax.disruptor;
  * @param <C> type third user specified argument to the translator.
  * @see EventTranslator
  */
+@FunctionalInterface
 public interface EventTranslatorThreeArg<T, A, B, C>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventTranslatorTwoArg.java
+++ b/src/main/java/com/lmax/disruptor/EventTranslatorTwoArg.java
@@ -23,6 +23,7 @@ package com.lmax.disruptor;
  * @param <B> type second user specified argument to the translator.
  * @see EventTranslator
  */
+@FunctionalInterface
 public interface EventTranslatorTwoArg<T, A, B>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventTranslatorVararg.java
+++ b/src/main/java/com/lmax/disruptor/EventTranslatorVararg.java
@@ -21,6 +21,7 @@ package com.lmax.disruptor;
  * @param <T> event implementation storing the data for sharing during exchange or parallel coordination of an event.
  * @see EventTranslator
  */
+@FunctionalInterface
 public interface EventTranslatorVararg<T>
 {
     /**

--- a/src/main/java/com/lmax/disruptor/EventuallyGiveUpBatchRewindStrategy.java
+++ b/src/main/java/com/lmax/disruptor/EventuallyGiveUpBatchRewindStrategy.java
@@ -7,22 +7,31 @@ package com.lmax.disruptor;
 public class EventuallyGiveUpBatchRewindStrategy implements BatchRewindStrategy
 {
     private final long maxAttempts;
+    private final boolean rewind;
+
+    // Constructor which retains current functionality
+    public EventuallyGiveUpBatchRewindStrategy(final long maxAttempts)
+    {
+        this(maxAttempts, true);
+    }
 
     /**
      * @param maxAttempts numbers of Rewindable exceptions that can be thrown until exception is delegated
+     * @param rewind Whether to return {@link RewindAction#REWIND} or {@link RewindAction#RETRY}.
      */
-    public EventuallyGiveUpBatchRewindStrategy(final long maxAttempts)
+    public EventuallyGiveUpBatchRewindStrategy(final long maxAttempts, boolean rewind)
     {
         this.maxAttempts = maxAttempts;
+        this.rewind = rewind;
     }
 
     @Override
     public RewindAction handleRewindException(final RewindableException e, final int retriesAttempted)
     {
-        if (retriesAttempted == maxAttempts)
+        if (retriesAttempted >= maxAttempts)
         {
             return RewindAction.THROW;
         }
-        return RewindAction.REWIND;
+        return rewind ? RewindAction.REWIND : RewindAction.RETRY;
     }
 }

--- a/src/main/java/com/lmax/disruptor/EventuallyGiveUpBatchRewindStrategy.java
+++ b/src/main/java/com/lmax/disruptor/EventuallyGiveUpBatchRewindStrategy.java
@@ -19,7 +19,7 @@ public class EventuallyGiveUpBatchRewindStrategy implements BatchRewindStrategy
      * @param maxAttempts numbers of Rewindable exceptions that can be thrown until exception is delegated
      * @param rewind Whether to return {@link RewindAction#REWIND} or {@link RewindAction#RETRY}.
      */
-    public EventuallyGiveUpBatchRewindStrategy(final long maxAttempts, boolean rewind)
+    public EventuallyGiveUpBatchRewindStrategy(final long maxAttempts, final boolean rewind)
     {
         this.maxAttempts = maxAttempts;
         this.rewind = rewind;

--- a/src/main/java/com/lmax/disruptor/NanosecondPauseBatchRewindStrategy.java
+++ b/src/main/java/com/lmax/disruptor/NanosecondPauseBatchRewindStrategy.java
@@ -22,7 +22,7 @@ public class NanosecondPauseBatchRewindStrategy implements BatchRewindStrategy
      * @param  nanoSecondPauseTime Amount of nanos to pause for when a rewindable exception is thrown.
      * @param rewind Whether to return {@link RewindAction#REWIND} or {@link RewindAction#RETRY}.
      */
-    public NanosecondPauseBatchRewindStrategy(final long nanoSecondPauseTime, boolean rewind)
+    public NanosecondPauseBatchRewindStrategy(final long nanoSecondPauseTime, final boolean rewind)
     {
         this.nanoSecondPauseTime = nanoSecondPauseTime;
         this.rewind = rewind;

--- a/src/main/java/com/lmax/disruptor/NanosecondPauseBatchRewindStrategy.java
+++ b/src/main/java/com/lmax/disruptor/NanosecondPauseBatchRewindStrategy.java
@@ -9,20 +9,29 @@ public class NanosecondPauseBatchRewindStrategy implements BatchRewindStrategy
 {
 
     private final long nanoSecondPauseTime;
+    private final boolean rewind;
+
+    // Constructor which retains current functionality
+    public NanosecondPauseBatchRewindStrategy(final long nanoSecondPauseTime)
+    {
+        this(nanoSecondPauseTime, true);
+    }
 
     /**
      * <p>Strategy for handling a rewindableException that will pause for a specified amount of nanos.</p>
-     * @param  nanoSecondPauseTime Amount of nanos to pause for when a rewindable exception is thrown
+     * @param  nanoSecondPauseTime Amount of nanos to pause for when a rewindable exception is thrown.
+     * @param rewind Whether to return {@link RewindAction#REWIND} or {@link RewindAction#RETRY}.
      */
-    public NanosecondPauseBatchRewindStrategy(final long nanoSecondPauseTime)
+    public NanosecondPauseBatchRewindStrategy(final long nanoSecondPauseTime, boolean rewind)
     {
         this.nanoSecondPauseTime = nanoSecondPauseTime;
+        this.rewind = rewind;
     }
 
     @Override
     public RewindAction handleRewindException(final RewindableException e, final int retriesAttempted)
     {
         LockSupport.parkNanos(nanoSecondPauseTime);
-        return RewindAction.REWIND;
+        return rewind ? RewindAction.REWIND : RewindAction.RETRY;
     }
 }

--- a/src/main/java/com/lmax/disruptor/RewindAction.java
+++ b/src/main/java/com/lmax/disruptor/RewindAction.java
@@ -1,17 +1,20 @@
 package com.lmax.disruptor;
 
 /**
- * The result returned from the {@link BatchRewindStrategy} that decides whether to rewind or throw the exception
+ * The result returned from the {@link BatchRewindStrategy} that decides whether to rewind, retry or throw the exception
  */
 public enum RewindAction
 {
     /**
-     * Rewind and replay the whole batch from  he beginning
+     * Rewind and replay the whole batch from the beginning sequence value.
      */
     REWIND,
-
     /**
-     * rethrows the exception, delegating it to the configured {@link ExceptionHandler}
+     * Retry the batch from the latest sequence value.
+     */
+    RETRY,
+    /**
+     * Rethrows the exception, delegating it to the configured {@link ExceptionHandler}.
      */
     THROW
 }

--- a/src/main/java/com/lmax/disruptor/RewindAction.java
+++ b/src/main/java/com/lmax/disruptor/RewindAction.java
@@ -10,7 +10,7 @@ public enum RewindAction
      */
     REWIND,
     /**
-     * Retry the batch from the latest sequence value.
+     * Retry the batch from the current sequence value.
      */
     RETRY,
     /**

--- a/src/main/java/com/lmax/disruptor/SimpleBatchRewindStrategy.java
+++ b/src/main/java/com/lmax/disruptor/SimpleBatchRewindStrategy.java
@@ -1,13 +1,29 @@
 package com.lmax.disruptor;
 
+import java.util.Objects;
+
 /**
- * Batch rewind strategy that always rewinds
+ * Batch rewind strategy that always performs the specified {@link RewindAction}.
  */
 public class SimpleBatchRewindStrategy implements BatchRewindStrategy
 {
+
+    private final RewindAction action;
+
+    // Default constructor which retains current functionality
+    public SimpleBatchRewindStrategy()
+    {
+        this(RewindAction.REWIND);
+    }
+
+    public SimpleBatchRewindStrategy(final RewindAction action)
+    {
+        this.action = Objects.requireNonNull(action, "action");
+    }
+
     @Override
     public RewindAction handleRewindException(final RewindableException e, final int retriesAttempted)
     {
-        return RewindAction.REWIND;
+        return action;
     }
 }


### PR DESCRIPTION
This pull request:
- Implements `RewindAction#RETRY` which allows for replaying events from the current value of `nextSequence`, as opposed to `RewindAction#REWIND`, which replays events from the beginning of the batch.
- Implements the aforementioned behaviour into the existing implementations of `BatchRewindStrategy` while retaining existing functionality.
- Denotes functional interfaces as being `@FunctionalInterface`s.
- Upgrades Gradle from version `7.2` to the latest version `7.5.1`.
- Enables parallel execution and caching of Gradle tasks/builds to improvement build-time performance.