### PR TITLE
Use Util.getSequencesFor to create sequences from processors

### DIFF
--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -195,15 +195,11 @@ public class Disruptor<T>
             consumerRepository.add(processor);
         }
 
-        final Sequence[] sequences = new Sequence[processors.length];
-        for (int i = 0; i < processors.length; i++)
-        {
-            sequences[i] = processors[i].getSequence();
-        }
+        final Sequence[] sequences = Util.getSequencesFor(processors);
 
         ringBuffer.addGatingSequences(sequences);
 
-        return new EventHandlerGroup<>(this, consumerRepository, Util.getSequencesFor(processors));
+        return new EventHandlerGroup<>(this, consumerRepository, sequences);
     }
 
 


### PR DESCRIPTION
This change is a very minor cleanup.

The new code uses the expected helper to extract sequences from processors.

Also, the sequence array is now only created once and reused for `addGatingSequences` and `new EventHandlerGroup`, which should be safe because the `EventHandlerGroup` constructor makes defensive copies of input sequences.