### PR TITLE
Fix CVE-2020-15250 in 3.4.X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ repositories {
 
 dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:8.2'
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.1'
     perfCompile 'org.hdrhistogram:HdrHistogram:1.2.1'
 }
 


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-JAVA-JUNIT-1017047

Upgrading to Disruptor 4.0.X is difficult because it is not compatible with Log4j2 2.22.X
https://github.com/apache/logging-log4j2/issues/1829

I think it would be good to have a 3.4.5 release that has this CVE addressed.