### PR TITLE
Fix asciidoctor build by moving away from pygments highlighting to ro…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ plugins {
     id 'idea'
     id "io.github.reyerizo.gradle.jcstress" version "0.8.14"
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
-    id 'org.asciidoctor.jvm.gems' version '3.3.2'
     id "me.champeau.jmh" version "0.6.8"
     id "biz.aQute.bnd.builder" version "6.3.1"
 }
@@ -50,7 +49,6 @@ wrapper.gradleVersion = '7.6'
 
 repositories {
     mavenCentral()
-    ruby.gems()
 }
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_11

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -2,14 +2,6 @@
 // Configure ASCIIDoc publishing
 //
 
-dependencies {
-    asciidoctorGems 'rubygems:pygments.rb:2.+'
-}
-
-asciidoctorj {
-    requires("pygments")
-}
-
 asciidoctor {
     languages 'en'
     resources {
@@ -28,7 +20,7 @@ asciidoctor {
     // the documents themselves - so to some degree it's pointless setting anything
     // at a document level. That said, IntelliJ IDEA doesn't know this, so it's
     // still kind of nice to have them at a document level so it doesn't complain!
-    attributes 'source-highlighter': 'pygments',
+    attributes 'source-highlighter': 'rouge',
             'toc': 'left',
             'icons': 'font',
             'xrefstyle': 'short',
@@ -37,5 +29,4 @@ asciidoctor {
     baseDirFollowsSourceFile()
 
     asciidoctorj.version = '2.4.3'
-    dependsOn asciidoctorGemsPrepare
 }


### PR DESCRIPTION
Gradle build is currently failing due to 

```
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.burgstaller:okhttp-digest:1.10.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/com/burgstaller/okhttp-digest/1.10/okhttp-digest-1.10.pom
```

Let's remove the need for this dependency by moving ascii doctor to use `rouge` highlighter instead `pygment` 