### PR TITLE
Add @FunctionalInteface annotation for the eventhandlerbase

### DIFF
--- a/src/main/java/com/lmax/disruptor/EventHandlerBase.java
+++ b/src/main/java/com/lmax/disruptor/EventHandlerBase.java
@@ -15,6 +15,7 @@
  */
 package com.lmax.disruptor;
 
+@FunctionalInterface
 interface EventHandlerBase<T> extends EventHandlerIdentity
 {
     /**


### PR DESCRIPTION
Disruptor uses java Lambdas pretty liberally in its documentation.  This is fine, but there's an annotation to designate this. 

While it's not strictly required, as Java will coerce even without it, a lack of the @FunctionalInterface makes it so Clojure cannot use its lambda syntax with Disruptor.  

Since I don't really see any reason *not* to have this annotation, I think it should be added. 