### PR TITLE
Add producer wait strategies for capacity backoff

### DIFF
--- a/src/docs/asciidoc/en/user-guide/10_using_the_disruptor.adoc
+++ b/src/docs/asciidoc/en/user-guide/10_using_the_disruptor.adoc
@@ -314,7 +314,8 @@ public class LongEventMain
             bufferSize,
             DaemonThreadFactory.INSTANCE,
             ProducerType.SINGLE, // <1>
-            new BlockingWaitStrategy() // <2>
+            new BlockingWaitStrategy(), // <2>
+            PhasedBackoffProducerWaitStrategy.withDefaults() // <3>
         );
         //.....
     }
@@ -322,6 +323,7 @@ public class LongEventMain
 ----
 <1> Use `ProducerType#SINGLE` to create a `SingleProducerSequencer`; use `ProducerType#MULTI` to create a `MultiProducerSequence`
 <2> Set the desired `WaitStrategy`
+<3> Set the desired `ProducerWaitStrategy` (for producers waiting on capacity)
 
 
 [#_single_vs_multiple_producers]
@@ -400,6 +402,30 @@ Like the `YieldingWaitStrategy`, it can be used in low-latency systems, but puts
 
 This wait strategy should only be used if the number of `EventHandler` threads is lower than the number of physical cores on the box, e.g. hyper-threading should be disabled.
 --
+
+[#_producer_wait_strategies]
+==== Producer Wait Strategies
+
+Producers also need to wait when the ring buffer is full. By default, producers will park briefly when capacity is not available.
+You can customize this behavior independently of the consumer `WaitStrategy`.
+
+- **ParkNanosProducerWaitStrategy** ->
+
+--
+Parks the producer thread for a short duration when capacity is unavailable.
+This is conservative on CPU usage and matches the historic behavior.
+--
+
+- **PhasedBackoffProducerWaitStrategy** ->
+
+--
+Spins, then yields, then parks. This can reduce tail latency during contention at the cost of higher CPU usage.
+--
+
+**When to use which**
+
+- Use `ParkNanosProducerWaitStrategy` when CPU conservation is more important than producer-side latency, or when you expect the ring buffer to be full only rarely.
+- Use `PhasedBackoffProducerWaitStrategy` when you expect frequent producer contention and want lower tail latency, and you can afford higher CPU usage.
 
 === Clearing Objects From the Ring Buffer
 

--- a/src/main/java/com/lmax/disruptor/AbstractSequencer.java
+++ b/src/main/java/com/lmax/disruptor/AbstractSequencer.java
@@ -32,6 +32,7 @@ public abstract class AbstractSequencer implements Sequencer
 
     protected final int bufferSize;
     protected final WaitStrategy waitStrategy;
+    protected final ProducerWaitStrategy producerWaitStrategy;
     protected final Sequence cursor = new Sequence(Sequencer.INITIAL_CURSOR_VALUE);
     protected volatile Sequence[] gatingSequences = new Sequence[0];
 
@@ -42,6 +43,21 @@ public abstract class AbstractSequencer implements Sequencer
      * @param waitStrategy The wait strategy used by this sequencer
      */
     public AbstractSequencer(final int bufferSize, final WaitStrategy waitStrategy)
+    {
+        this(bufferSize, waitStrategy, ParkNanosProducerWaitStrategy.INSTANCE);
+    }
+
+    /**
+     * Create with the specified buffer size, wait strategy, and producer wait strategy.
+     *
+     * @param bufferSize           The total number of entries, must be a positive power of 2.
+     * @param waitStrategy         The wait strategy used by this sequencer
+     * @param producerWaitStrategy The producer wait strategy for capacity waits
+     */
+    public AbstractSequencer(
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
     {
         if (bufferSize < 1)
         {
@@ -54,6 +70,7 @@ public abstract class AbstractSequencer implements Sequencer
 
         this.bufferSize = bufferSize;
         this.waitStrategy = waitStrategy;
+        this.producerWaitStrategy = producerWaitStrategy;
     }
 
     /**
@@ -129,6 +146,7 @@ public abstract class AbstractSequencer implements Sequencer
     {
         return "AbstractSequencer{" +
             "waitStrategy=" + waitStrategy +
+            ", producerWaitStrategy=" + producerWaitStrategy +
             ", cursor=" + cursor +
             ", gatingSequences=" + Arrays.toString(gatingSequences) +
             '}';

--- a/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
@@ -20,7 +20,6 @@ import com.lmax.disruptor.util.Util;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.Arrays;
-import java.util.concurrent.locks.LockSupport;
 
 
 /**
@@ -52,6 +51,26 @@ public final class MultiProducerSequencer extends AbstractSequencer
     public MultiProducerSequencer(final int bufferSize, final WaitStrategy waitStrategy)
     {
         super(bufferSize, waitStrategy);
+        availableBuffer = new int[bufferSize];
+        Arrays.fill(availableBuffer, -1);
+
+        indexMask = bufferSize - 1;
+        indexShift = Util.log2(bufferSize);
+    }
+
+    /**
+     * Construct a Sequencer with the selected wait strategy and buffer size.
+     *
+     * @param bufferSize           the size of the buffer that this will sequence over.
+     * @param waitStrategy         for those waiting on sequences.
+     * @param producerWaitStrategy for producers waiting on capacity.
+     */
+    public MultiProducerSequencer(
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
+    {
+        super(bufferSize, waitStrategy, producerWaitStrategy);
         availableBuffer = new int[bufferSize];
         Arrays.fill(availableBuffer, -1);
 
@@ -125,10 +144,12 @@ public final class MultiProducerSequencer extends AbstractSequencer
         if (wrapPoint > cachedGatingSequence || cachedGatingSequence > current)
         {
             long gatingSequence;
+            int idleCounter = 0;
             while (wrapPoint > (gatingSequence = Util.getMinimumSequence(gatingSequences, current)))
             {
-                LockSupport.parkNanos(1L); // TODO, should we spin based on the wait strategy?
+                idleCounter = producerWaitStrategy.idle(idleCounter);
             }
+            producerWaitStrategy.reset();
 
             gatingSequenceCache.set(gatingSequence);
         }

--- a/src/main/java/com/lmax/disruptor/ParkNanosProducerWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/ParkNanosProducerWaitStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor;
+
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Producer wait strategy that parks for a short duration.
+ */
+public final class ParkNanosProducerWaitStrategy implements ProducerWaitStrategy
+{
+    public static final ParkNanosProducerWaitStrategy INSTANCE = new ParkNanosProducerWaitStrategy(1L);
+
+    private final long parkNanos;
+
+    public ParkNanosProducerWaitStrategy(final long parkNanos)
+    {
+        if (parkNanos < 1L)
+        {
+            throw new IllegalArgumentException("parkNanos must be >= 1");
+        }
+        this.parkNanos = parkNanos;
+    }
+
+    @Override
+    public int idle(final int idleCounter)
+    {
+        LockSupport.parkNanos(parkNanos);
+        return idleCounter + 1;
+    }
+}

--- a/src/main/java/com/lmax/disruptor/PhasedBackoffProducerWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/PhasedBackoffProducerWaitStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Spins, then yields, then parks for producers waiting on capacity.
+ */
+public final class PhasedBackoffProducerWaitStrategy implements ProducerWaitStrategy
+{
+    private final int spinTries;
+    private final int yieldTries;
+    private final long parkPeriodNanos;
+
+    public PhasedBackoffProducerWaitStrategy(
+        final int spinTries,
+        final int yieldTries,
+        final long parkPeriod,
+        final TimeUnit unit)
+    {
+        if (spinTries < 0)
+        {
+            throw new IllegalArgumentException("spinTries must be >= 0");
+        }
+        if (yieldTries < 0)
+        {
+            throw new IllegalArgumentException("yieldTries must be >= 0");
+        }
+        if (parkPeriod < 1L)
+        {
+            throw new IllegalArgumentException("parkPeriod must be >= 1");
+        }
+        this.spinTries = spinTries;
+        this.yieldTries = yieldTries;
+        this.parkPeriodNanos = unit.toNanos(parkPeriod);
+    }
+
+    public static PhasedBackoffProducerWaitStrategy withDefaults()
+    {
+        return new PhasedBackoffProducerWaitStrategy(100, 100, 1L, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public int idle(final int idleCounter)
+    {
+        if (idleCounter < spinTries)
+        {
+            Thread.onSpinWait();
+            return idleCounter + 1;
+        }
+        if (idleCounter < spinTries + yieldTries)
+        {
+            Thread.yield();
+            return idleCounter + 1;
+        }
+
+        LockSupport.parkNanos(parkPeriodNanos);
+        return idleCounter + 1;
+    }
+}

--- a/src/main/java/com/lmax/disruptor/ProducerWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/ProducerWaitStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2011 LMAX Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lmax.disruptor;
+
+/**
+ * Strategy employed for producers waiting on ring buffer capacity.
+ */
+public interface ProducerWaitStrategy
+{
+    /**
+     * Perform an idle action and return the updated idle counter.
+     *
+     * @param idleCounter current idle counter value.
+     * @return updated idle counter value.
+     */
+    int idle(int idleCounter);
+
+    /**
+     * Reset any internal state after progress has been made.
+     */
+    default void reset()
+    {
+    }
+}

--- a/src/main/java/com/lmax/disruptor/RingBuffer.java
+++ b/src/main/java/com/lmax/disruptor/RingBuffer.java
@@ -132,6 +132,29 @@ public final class RingBuffer<E> extends RingBufferFields<E> implements Cursored
     }
 
     /**
+     * Create a new multiple producer RingBuffer with the specified wait strategy and producer wait strategy.
+     *
+     * @param <E> Class of the event stored in the ring buffer.
+     * @param factory              used to create the events within the ring buffer.
+     * @param bufferSize           number of elements to create within the ring buffer.
+     * @param waitStrategy         used to determine how to wait for new elements to become available.
+     * @param producerWaitStrategy used to determine how producers wait for capacity.
+     * @return a constructed ring buffer.
+     * @throws IllegalArgumentException if bufferSize is less than 1 or not a power of 2
+     * @see MultiProducerSequencer
+     */
+    public static <E> RingBuffer<E> createMultiProducer(
+        final EventFactory<E> factory,
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
+    {
+        MultiProducerSequencer sequencer = new MultiProducerSequencer(bufferSize, waitStrategy, producerWaitStrategy);
+
+        return new RingBuffer<>(factory, sequencer);
+    }
+
+    /**
      * Create a new multiple producer RingBuffer using the default wait strategy  {@link BlockingWaitStrategy}.
      *
      * @param <E> Class of the event stored in the ring buffer.
@@ -163,6 +186,29 @@ public final class RingBuffer<E> extends RingBufferFields<E> implements Cursored
         final WaitStrategy waitStrategy)
     {
         SingleProducerSequencer sequencer = new SingleProducerSequencer(bufferSize, waitStrategy);
+
+        return new RingBuffer<>(factory, sequencer);
+    }
+
+    /**
+     * Create a new single producer RingBuffer with the specified wait strategy and producer wait strategy.
+     *
+     * @param <E> Class of the event stored in the ring buffer.
+     * @param factory              used to create the events within the ring buffer.
+     * @param bufferSize           number of elements to create within the ring buffer.
+     * @param waitStrategy         used to determine how to wait for new elements to become available.
+     * @param producerWaitStrategy used to determine how producers wait for capacity.
+     * @return a constructed ring buffer.
+     * @throws IllegalArgumentException if bufferSize is less than 1 or not a power of 2
+     * @see SingleProducerSequencer
+     */
+    public static <E> RingBuffer<E> createSingleProducer(
+        final EventFactory<E> factory,
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
+    {
+        SingleProducerSequencer sequencer = new SingleProducerSequencer(bufferSize, waitStrategy, producerWaitStrategy);
 
         return new RingBuffer<>(factory, sequencer);
     }
@@ -205,6 +251,36 @@ public final class RingBuffer<E> extends RingBufferFields<E> implements Cursored
                 return createSingleProducer(factory, bufferSize, waitStrategy);
             case MULTI:
                 return createMultiProducer(factory, bufferSize, waitStrategy);
+            default:
+                throw new IllegalStateException(producerType.toString());
+        }
+    }
+
+    /**
+     * Create a new Ring Buffer with the specified producer type (SINGLE or MULTI).
+     *
+     * @param <E> Class of the event stored in the ring buffer.
+     * @param producerType        producer type to use {@link ProducerType}.
+     * @param factory             used to create events within the ring buffer.
+     * @param bufferSize          number of elements to create within the ring buffer.
+     * @param waitStrategy        used to determine how to wait for new elements to become available.
+     * @param producerWaitStrategy used to determine how producers wait for capacity.
+     * @return a constructed ring buffer.
+     * @throws IllegalArgumentException if bufferSize is less than 1 or not a power of 2
+     */
+    public static <E> RingBuffer<E> create(
+        final ProducerType producerType,
+        final EventFactory<E> factory,
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
+    {
+        switch (producerType)
+        {
+            case SINGLE:
+                return createSingleProducer(factory, bufferSize, waitStrategy, producerWaitStrategy);
+            case MULTI:
+                return createMultiProducer(factory, bufferSize, waitStrategy, producerWaitStrategy);
             default:
                 throw new IllegalStateException(producerType.toString());
         }

--- a/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
@@ -20,7 +20,6 @@ import com.lmax.disruptor.util.Util;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.locks.LockSupport;
 
 abstract class SingleProducerSequencerPad extends AbstractSequencer
 {
@@ -37,6 +36,14 @@ abstract class SingleProducerSequencerPad extends AbstractSequencer
     {
         super(bufferSize, waitStrategy);
     }
+
+    SingleProducerSequencerPad(
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
+    {
+        super(bufferSize, waitStrategy, producerWaitStrategy);
+    }
 }
 
 abstract class SingleProducerSequencerFields extends SingleProducerSequencerPad
@@ -44,6 +51,14 @@ abstract class SingleProducerSequencerFields extends SingleProducerSequencerPad
     SingleProducerSequencerFields(final int bufferSize, final WaitStrategy waitStrategy)
     {
         super(bufferSize, waitStrategy);
+    }
+
+    SingleProducerSequencerFields(
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
+    {
+        super(bufferSize, waitStrategy, producerWaitStrategy);
     }
 
     /**
@@ -81,6 +96,21 @@ public final class SingleProducerSequencer extends SingleProducerSequencerFields
     public SingleProducerSequencer(final int bufferSize, final WaitStrategy waitStrategy)
     {
         super(bufferSize, waitStrategy);
+    }
+
+    /**
+     * Construct a Sequencer with the selected wait strategy and buffer size.
+     *
+     * @param bufferSize           the size of the buffer that this will sequence over.
+     * @param waitStrategy         for those waiting on sequences.
+     * @param producerWaitStrategy for producers waiting on capacity.
+     */
+    public SingleProducerSequencer(
+        final int bufferSize,
+        final WaitStrategy waitStrategy,
+        final ProducerWaitStrategy producerWaitStrategy)
+    {
+        super(bufferSize, waitStrategy, producerWaitStrategy);
     }
 
     /**
@@ -151,10 +181,12 @@ public final class SingleProducerSequencer extends SingleProducerSequencerFields
             cursor.setVolatile(nextValue);  // StoreLoad fence
 
             long minSequence;
+            int idleCounter = 0;
             while (wrapPoint > (minSequence = Util.getMinimumSequence(gatingSequences, nextValue)))
             {
-                LockSupport.parkNanos(1L); // TODO: Use waitStrategy to spin?
+                idleCounter = producerWaitStrategy.idle(idleCounter);
             }
+            producerWaitStrategy.reset();
 
             this.cachedValue = minSequence;
         }

--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -33,6 +33,7 @@ import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.Sequence;
 import com.lmax.disruptor.SequenceBarrier;
 import com.lmax.disruptor.TimeoutException;
+import com.lmax.disruptor.ProducerWaitStrategy;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.util.Util;
 
@@ -98,6 +99,29 @@ public class Disruptor<T>
     {
         this(
             RingBuffer.create(producerType, eventFactory, ringBufferSize, waitStrategy),
+            threadFactory);
+    }
+
+    /**
+     * Create a new Disruptor.
+     *
+     * @param eventFactory         the factory to create events in the ring buffer.
+     * @param ringBufferSize       the size of the ring buffer, must be power of 2.
+     * @param threadFactory        a {@link ThreadFactory} to create threads for processors.
+     * @param producerType         the claim strategy to use for the ring buffer.
+     * @param waitStrategy         the wait strategy to use for the ring buffer.
+     * @param producerWaitStrategy the wait strategy to use for producers waiting on capacity.
+     */
+    public Disruptor(
+            final EventFactory<T> eventFactory,
+            final int ringBufferSize,
+            final ThreadFactory threadFactory,
+            final ProducerType producerType,
+            final WaitStrategy waitStrategy,
+            final ProducerWaitStrategy producerWaitStrategy)
+    {
+        this(
+            RingBuffer.create(producerType, eventFactory, ringBufferSize, waitStrategy, producerWaitStrategy),
             threadFactory);
     }
 

--- a/src/test/java/com/lmax/disruptor/ProducerWaitStrategyTest.java
+++ b/src/test/java/com/lmax/disruptor/ProducerWaitStrategyTest.java
@@ -1,0 +1,43 @@
+package com.lmax.disruptor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProducerWaitStrategyTest
+{
+    @Test
+    void parkNanosStrategyValidatesArguments()
+    {
+        assertThrows(IllegalArgumentException.class, () -> new ParkNanosProducerWaitStrategy(0L));
+    }
+
+    @Test
+    void phasedBackoffStrategyValidatesArguments()
+    {
+        assertThrows(IllegalArgumentException.class, () ->
+            new PhasedBackoffProducerWaitStrategy(-1, 0, 1L, TimeUnit.NANOSECONDS));
+        assertThrows(IllegalArgumentException.class, () ->
+            new PhasedBackoffProducerWaitStrategy(0, -1, 1L, TimeUnit.NANOSECONDS));
+        assertThrows(IllegalArgumentException.class, () ->
+            new PhasedBackoffProducerWaitStrategy(0, 0, 0L, TimeUnit.NANOSECONDS));
+    }
+
+    @Test
+    void idleCounterIncrementsAndResetIsNoOp()
+    {
+        ProducerWaitStrategy strategy = new PhasedBackoffProducerWaitStrategy(1, 1, 1L, TimeUnit.NANOSECONDS);
+        int idleCounter = 0;
+
+        idleCounter = strategy.idle(idleCounter);
+        assertEquals(1, idleCounter);
+
+        idleCounter = strategy.idle(idleCounter);
+        assertEquals(2, idleCounter);
+
+        strategy.reset();
+    }
+}


### PR DESCRIPTION
 ## Summary
  - add producer-side wait strategy API and implementations
  - wire producer backoff into single/multi sequencers
  - add RingBuffer/Disruptor overloads and docs updates
  - add unit tests for producer wait strategies

  ## Testing
  - ./gradlew test