### PR TITLE
Fix Javadoc @see tag and typo in error message in RingBuffer

### DIFF
--- a/src/main/java/com/lmax/disruptor/RingBuffer.java
+++ b/src/main/java/com/lmax/disruptor/RingBuffer.java
@@ -175,7 +175,7 @@ public final class RingBuffer<E> extends RingBufferFields<E> implements Cursored
      * @param bufferSize number of elements to create within the ring buffer.
      * @return a constructed ring buffer.
      * @throws IllegalArgumentException if <code>bufferSize</code> is less than 1 or not a power of 2
-     * @see MultiProducerSequencer
+     * @see SingleProducerSequencer
      */
     public static <E> RingBuffer<E> createSingleProducer(final EventFactory<E> factory, final int bufferSize)
     {
@@ -943,7 +943,7 @@ public final class RingBuffer<E> extends RingBufferFields<E> implements Cursored
         {
             throw new IllegalArgumentException(
                 "A batchSize of: " + batchSize +
-                    " with batchStatsAt of: " + batchStartsAt +
+                    " with batchStartsAt of: " + batchStartsAt +
                     " will overrun the available number of arguments: " + (arg0.length - batchStartsAt));
         }
     }


### PR DESCRIPTION
## Summary

Fix two minor documentation/message issues in RingBuffer.java:

1. **Javadoc @see tag**: `createSingleProducer(factory, bufferSize)` referenced
   `MultiProducerSequencer` instead of `SingleProducerSequencer`.

2. **Error message typo**: `batchOverRuns()` contained `"batchStatsAt"` which
   should be `"batchStartsAt"` (matches the actual parameter name).

## Changes

- RingBuffer.java: correct @see tag on createSingleProducer
- RingBuffer.java: fix typo in batchOverRuns error message

## Testing

- Existing tests pass: `./gradlew test`
- No behaviour changes, documentation and message fixes only.