### PR TITLE
Fix comment typos and error message inconsistencies

### DIFF
--- a/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java
@@ -113,7 +113,7 @@ public final class MultiProducerSequencer extends AbstractSequencer
     {
         if (n < 1 || n > bufferSize)
         {
-            throw new IllegalArgumentException("n must be > 0 and < bufferSize");
+            throw new IllegalArgumentException("n must be > 0 and <= bufferSize");
         }
 
         long current = cursor.getAndAdd(n);

--- a/src/main/java/com/lmax/disruptor/PhasedBackoffWaitStrategy.java
+++ b/src/main/java/com/lmax/disruptor/PhasedBackoffWaitStrategy.java
@@ -32,8 +32,8 @@ public final class PhasedBackoffWaitStrategy implements WaitStrategy
 
     /**
      *
-     * @param spinTimeout The maximum time in to busy spin for.
-     * @param yieldTimeout The maximum time in to yield for.
+     * @param spinTimeout The maximum time to busy spin for.
+     * @param yieldTimeout The maximum time to yield for.
      * @param units Time units used for the timeout values.
      * @param fallbackStrategy After spinning + yielding, the strategy to fall back to
      */
@@ -51,8 +51,8 @@ public final class PhasedBackoffWaitStrategy implements WaitStrategy
     /**
      * Construct {@link PhasedBackoffWaitStrategy} with fallback to {@link BlockingWaitStrategy}
      *
-     * @param spinTimeout The maximum time in to busy spin for.
-     * @param yieldTimeout The maximum time in to yield for.
+     * @param spinTimeout The maximum time to busy spin for.
+     * @param yieldTimeout The maximum time to yield for.
      * @param units Time units used for the timeout values.
      * @return The constructed wait strategy.
      */
@@ -69,8 +69,8 @@ public final class PhasedBackoffWaitStrategy implements WaitStrategy
     /**
      * Construct {@link PhasedBackoffWaitStrategy} with fallback to {@link LiteBlockingWaitStrategy}
      *
-     * @param spinTimeout The maximum time in to busy spin for.
-     * @param yieldTimeout The maximum time in to yield for.
+     * @param spinTimeout The maximum time to busy spin for.
+     * @param yieldTimeout The maximum time to yield for.
      * @param units Time units used for the timeout values.
      * @return The constructed wait strategy.
      */
@@ -87,8 +87,8 @@ public final class PhasedBackoffWaitStrategy implements WaitStrategy
     /**
      * Construct {@link PhasedBackoffWaitStrategy} with fallback to {@link SleepingWaitStrategy}
      *
-     * @param spinTimeout The maximum time in to busy spin for.
-     * @param yieldTimeout The maximum time in to yield for.
+     * @param spinTimeout The maximum time to busy spin for.
+     * @param yieldTimeout The maximum time to yield for.
      * @param units Time units used for the timeout values.
      * @return The constructed wait strategy.
      */

--- a/src/main/java/com/lmax/disruptor/RewindAction.java
+++ b/src/main/java/com/lmax/disruptor/RewindAction.java
@@ -6,7 +6,7 @@ package com.lmax.disruptor;
 public enum RewindAction
 {
     /**
-     * Rewind and replay the whole batch from  he beginning
+     * Rewind and replay the whole batch from the beginning
      */
     REWIND,
 

--- a/src/main/java/com/lmax/disruptor/RingBuffer.java
+++ b/src/main/java/com/lmax/disruptor/RingBuffer.java
@@ -901,7 +901,7 @@ public final class RingBuffer<E> extends RingBufferFields<E> implements Cursored
     {
         if (batchStartsAt < 0 || batchSize < 0)
         {
-            throw new IllegalArgumentException("Both batchStartsAt and batchSize must be positive but got: batchStartsAt " + batchStartsAt + " and batchSize " + batchSize);
+            throw new IllegalArgumentException("Both batchStartsAt and batchSize must not be negative but got: batchStartsAt " + batchStartsAt + " and batchSize " + batchSize);
         }
         else if (batchSize > bufferSize)
         {

--- a/src/main/java/com/lmax/disruptor/Sequencer.java
+++ b/src/main/java/com/lmax/disruptor/Sequencer.java
@@ -29,7 +29,7 @@ public interface Sequencer extends Cursored, Sequenced
      * Claim a specific sequence.  Only used if initialising the ring buffer to
      * a specific value.
      *
-     * @param sequence The sequence to initialise too.
+     * @param sequence The sequence to initialise to.
      */
     void claim(long sequence);
 

--- a/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
+++ b/src/main/java/com/lmax/disruptor/SingleProducerSequencer.java
@@ -137,7 +137,7 @@ public final class SingleProducerSequencer extends SingleProducerSequencerFields
 
         if (n < 1 || n > bufferSize)
         {
-            throw new IllegalArgumentException("n must be > 0 and < bufferSize");
+            throw new IllegalArgumentException("n must be > 0 and <= bufferSize");
         }
 
         long nextValue = this.nextValue;

--- a/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
+++ b/src/main/java/com/lmax/disruptor/dsl/Disruptor.java
@@ -73,7 +73,7 @@ public class Disruptor<T>
      *
      * @param eventFactory   the factory to create events in the ring buffer.
      * @param ringBufferSize the size of the ring buffer.
-     * @param threadFactory  a {@link ThreadFactory} to create threads to for processors.
+     * @param threadFactory  a {@link ThreadFactory} to create threads for processors.
      */
     public Disruptor(final EventFactory<T> eventFactory, final int ringBufferSize, final ThreadFactory threadFactory)
     {

--- a/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
+++ b/src/main/java/com/lmax/disruptor/dsl/ExceptionHandlerWrapper.java
@@ -35,7 +35,7 @@ public class ExceptionHandlerWrapper<T> implements ExceptionHandler<T>
     @Override
     public void handleOnShutdownException(final Throwable ex)
     {
-        getExceptionHandler() .handleOnShutdownException(ex);
+        getExceptionHandler().handleOnShutdownException(ex);
     }
 
     private ExceptionHandler<? super T> getExceptionHandler()


### PR DESCRIPTION
## Summary
Fix minor documentation and error message issues across the codebase so the messages match the actual validation logic.

**Javadoc/comment typos**: corrected misspelled and malformed wording in `Disruptor`, `RewindAction`, `PhasedBackoffWaitStrategy`, `Sequencer`, and `ExceptionHandlerWrapper`.

**Error message inconsistencies**: exception messages did not match the actual guard conditions they describe.

## Changes
### Javadoc/comment typos
- `Disruptor.java`: "to create threads **to for** processors" -> "to create threads **for** processors"
- `RewindAction.java`: "from  **he** beginning" -> "from **the** beginning"
- `PhasedBackoffWaitStrategy.java`: "time **in to** busy spin/yield for" -> "time **to** busy spin/yield for" (6 occurrences)
- `Sequencer.java`: "The sequence to initialise **too**." -> "The sequence to initialise **to**."
- `ExceptionHandlerWrapper.java`: removed stray space in `getExceptionHandler().handleOnShutdownException`

### Error message inconsistencies (guard semantics unchanged)
- `RingBuffer.java`: "must be **positive**" -> "must **not be negative**" (the guard rejects only negative values; 0 is valid)
- `SingleProducerSequencer.java`: "n must be > 0 and **<** bufferSize" -> "n must be > 0 and **<=** bufferSize" (n == bufferSize is allowed)
- `MultiProducerSequencer.java`: same message fix as above

## Testing
`./gradlew test`