### PR TITLE
docs: clarify remaining capacity under concurrent producers

### DIFF
--- a/src/main/java/com/lmax/disruptor/Sequenced.java
+++ b/src/main/java/com/lmax/disruptor/Sequenced.java
@@ -23,9 +23,18 @@ public interface Sequenced
     boolean hasAvailableCapacity(int requiredCapacity);
 
     /**
-     * Get the remaining capacity for this sequencer.
+     * Get an estimate of the remaining capacity for this sequencer.
      *
-     * @return The number of slots remaining.
+     * <p>This is a concurrent operation and the result is only an indication of the
+     * available capacity. It is not an atomic snapshot and may be stale by the time
+     * it is returned. With multiple producers, sequences may be reserved before they
+     * are published, so the result may be negative while producers are contending for
+     * a full buffer.
+     *
+     * <p>Use {@link #hasAvailableCapacity(int)} or {@link #tryNext()} when making
+     * capacity decisions that must be correct.
+     *
+     * @return an estimate of the number of slots remaining
      */
     long remainingCapacity();
 


### PR DESCRIPTION
## Summary

Clarifies the concurrency semantics of `Sequenced.remainingCapacity()` in response to #511.

The method does not provide an atomic capacity snapshot. Under concurrent producers, sequences may be reserved before they are published, and the estimate may be stale or negative while producers contend for a full buffer. The documentation now recommends `hasAvailableCapacity(int)` or `tryNext()` when a capacity decision must be correct.

This intentionally does not change the existing cursor-read order: as discussed in #511, reading the cursor once or twice has different consistency trade-offs, and neither option is universally preferable.

## Validation

- `git diff --check` passed.
- Gradle tests could not be run locally because the Gradle 8.10 wrapper distribution download timed out in the environment.
- No runtime behavior was changed; this is a Javadoc-only change.

Closes #511
